### PR TITLE
feat(slonik): add default migrations path "migrations"

### DIFF
--- a/packages/slonik/src/migrate.ts
+++ b/packages/slonik/src/migrate.ts
@@ -23,7 +23,12 @@ const migrate = async (config: ApiConfig) => {
     defaultDatabase: "postgres",
   } as MigrateDBConfig;
 
-  await runMigrations(dbConfig, slonikConfig.migrations.path);
+  const defaultMigrationsPath = "migrations";
+
+  await runMigrations(
+    dbConfig,
+    slonikConfig?.migrations?.path || defaultMigrationsPath
+  );
 };
 
 export default migrate;

--- a/packages/slonik/src/types.ts
+++ b/packages/slonik/src/types.ts
@@ -9,7 +9,7 @@ type Database = {
 
 type SlonikConfig = {
   db: ConnectionOptions;
-  migrations: {
+  migrations?: {
     path: string;
   };
 };


### PR DESCRIPTION
`config.slonik.migrations` is now optional.