### PR TITLE
Add repository link

### DIFF
--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -12,6 +12,10 @@
   },
   "main": "./dist/dzangolab-fastify-mailer.umd.cjs",
   "module": "./dist/dzangolab-fastify-mailer.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dzangolab/fastify.git"
+  },
   "types": "./dist/types/index.d.ts",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
I had a hard time find the source from <https://www.npmjs.com/package/@dzangolab/fastify-mailer>.