### PR TITLE
feat(slonik): add support for custom sql factory class

### DIFF
--- a/packages/slonik/src/service.ts
+++ b/packages/slonik/src/service.ts
@@ -170,10 +170,16 @@ abstract class BaseService<
     }
 
     if (!this._factory) {
-      this._factory = new DefaultSqlFactory<T, C, U>(this);
+      const sqlFactoryClass = this.sqlFactoryClass;
+
+      this._factory = new sqlFactoryClass<T, C, U>(this);
     }
 
     return this._factory as SqlFactory<T, C, U>;
+  }
+
+  get schema(): string {
+    return this._schema || "public";
   }
 
   get sortDirection(): SortDirection {
@@ -184,8 +190,8 @@ abstract class BaseService<
     return (this.constructor as typeof BaseService).SORT_KEY;
   }
 
-  get schema(): string {
-    return this._schema || "public";
+  get sqlFactoryClass() {
+    return DefaultSqlFactory;
   }
 
   get table(): string {


### PR DESCRIPTION
In slonik package, make it easier to customize the SqlFactory class in the Service.
Instead of having to rewrite the getFactory method, s Service class now only has to define its `sqlFactoryClass` property

```
import MySqlFactory from "...";

class MyService extends BaseService {
  ...
  get sqlFactoryClass() {
    return MySqlFactory;
  }
```

I have tested this minimally in the website-build package, and it needs to be tested much more thoroughly. In particular, please check other projects to see if they already define a custom SqlFactory class.
