### PR TITLE
Return a consistent 422 response for invitation CustomErrors

### DIFF
--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -4,8 +4,8 @@ A [Fastify](https://github.com/fastify/fastify) plugin that provides an easy int
 
 ## Requirements
 
-* [@prefabs.tech/fastify-config](../config/)
-* [@fastify/sensible](https://github.com/fastify/fastify-sensible)
+- [@prefabs.tech/fastify-config](../config/)
+- [@fastify/sensible](https://github.com/fastify/fastify-sensible)
 
 ## Installation
 
@@ -48,6 +48,7 @@ const start = async () => {
 
 start();
 ```
+
 ### Options
 
 #### stackTrace
@@ -100,6 +101,7 @@ fastify.get('/test', async (req, reply) => {
 ```
 
 ### Throw `CustomError` (or subclass)
+
 - Modules **must throw** an instance of `CustomError` (or a class extending it).
 - This ensures errors can be consistently caught and appropriate actions taken.
 
@@ -112,3 +114,4 @@ if (!file) {
   throw new CustomError("File not found", "FILE_NOT_FOUND_ERROR");
 }
 ```
+

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -4,8 +4,8 @@ A [Fastify](https://github.com/fastify/fastify) plugin that provides an easy int
 
 ## Requirements
 
-- [@prefabs.tech/fastify-config](../config/)
-- [@fastify/sensible](https://github.com/fastify/fastify-sensible)
+* [@prefabs.tech/fastify-config](../config/)
+* [@fastify/sensible](https://github.com/fastify/fastify-sensible)
 
 ## Installation
 
@@ -48,7 +48,6 @@ const start = async () => {
 
 start();
 ```
-
 ### Options
 
 #### stackTrace
@@ -101,7 +100,6 @@ fastify.get('/test', async (req, reply) => {
 ```
 
 ### Throw `CustomError` (or subclass)
-
 - Modules **must throw** an instance of `CustomError` (or a class extending it).
 - This ensures errors can be consistently caught and appropriate actions taken.
 
@@ -114,4 +112,3 @@ if (!file) {
   throw new CustomError("File not found", "FILE_NOT_FOUND_ERROR");
 }
 ```
-

--- a/packages/user/src/model/invitations/handlers/__test__/createInvitation.spec.ts
+++ b/packages/user/src/model/invitations/handlers/__test__/createInvitation.spec.ts
@@ -75,11 +75,7 @@ describe("createInvitation handler", () => {
     });
   });
 
-  it("throws createError(422) for other service CustomError codes", async () => {
-    const sentinel = new Error("wrapped");
-
-    createError.mockReturnValue(sentinel);
-
+  it("returns the same 422 body for other CustomError codes", async () => {
     vi.mocked(getInvitationService).mockReturnValue({
       create: vi
         .fn()
@@ -91,10 +87,15 @@ describe("createInvitation handler", () => {
       send: vi.fn(),
     } as unknown as FastifyReply;
 
-    await expect(createInvitation(baseRequest, reply)).rejects.toBe(sentinel);
+    await createInvitation(baseRequest, reply);
 
-    expect(createError).toHaveBeenCalledWith(422, "Other message", {
+    expect(createError).not.toHaveBeenCalled();
+    expect(reply.code).toHaveBeenCalledWith(422);
+    expect(reply.send).toHaveBeenCalledWith({
       code: "SOME_OTHER_CODE",
+      error: "Unprocessable Entity",
+      message: "Other message",
+      statusCode: 422,
     });
   });
 });

--- a/packages/user/src/model/invitations/handlers/__test__/createInvitation.spec.ts
+++ b/packages/user/src/model/invitations/handlers/__test__/createInvitation.spec.ts
@@ -1,0 +1,100 @@
+import { CustomError } from "@prefabs.tech/fastify-error-handler";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ERROR_CODES } from "../../../../constants";
+import getInvitationService from "../../../../lib/getInvitationService";
+import createInvitation from "../createInvitation";
+
+import type { FastifyReply } from "fastify";
+import type { SessionRequest } from "supertokens-node/framework/fastify";
+
+vi.mock("../../../../lib/getInvitationService", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../../../../lib/sendInvitation", () => ({
+  default: vi.fn(),
+}));
+
+describe("createInvitation handler", () => {
+  const createError = vi.fn();
+  const unauthorized = vi.fn();
+
+  const baseRequest = {
+    body: {
+      email: "invitee@example.com",
+      role: "USER",
+    },
+    config: {} as SessionRequest["config"],
+    dbSchema: undefined,
+    headers: {},
+    hostname: "localhost",
+    log: { error: vi.fn() },
+    server: {
+      httpErrors: {
+        createError,
+        unauthorized,
+      },
+    },
+    slonik: {},
+    user: { id: "inviter-1" },
+  } as unknown as SessionRequest;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createError.mockReset();
+    unauthorized.mockReset();
+  });
+
+  it("returns 422 body without createError when invitation already exists", async () => {
+    vi.mocked(getInvitationService).mockReturnValue({
+      create: vi
+        .fn()
+        .mockRejectedValue(
+          new CustomError(
+            "Invitation already exists for this email.",
+            ERROR_CODES.INVITATION_ALREADY_EXISTS,
+          ),
+        ),
+    } as never);
+
+    const reply = {
+      code: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    } as unknown as FastifyReply;
+
+    await createInvitation(baseRequest, reply);
+
+    expect(createError).not.toHaveBeenCalled();
+    expect(reply.code).toHaveBeenCalledWith(422);
+    expect(reply.send).toHaveBeenCalledWith({
+      statusCode: 422,
+      code: ERROR_CODES.INVITATION_ALREADY_EXISTS,
+      error: "Unprocessable Entity",
+      message: "Invitation already exists for this email.",
+    });
+  });
+
+  it("throws createError(422) for other service CustomError codes", async () => {
+    const sentinel = new Error("wrapped");
+
+    createError.mockReturnValue(sentinel);
+
+    vi.mocked(getInvitationService).mockReturnValue({
+      create: vi
+        .fn()
+        .mockRejectedValue(new CustomError("Other message", "SOME_OTHER_CODE")),
+    } as never);
+
+    const reply = {
+      code: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    } as unknown as FastifyReply;
+
+    await expect(createInvitation(baseRequest, reply)).rejects.toBe(sentinel);
+
+    expect(createError).toHaveBeenCalledWith(422, "Other message", {
+      code: "SOME_OTHER_CODE",
+    });
+  });
+});

--- a/packages/user/src/model/invitations/handlers/__test__/createInvitation.spec.ts
+++ b/packages/user/src/model/invitations/handlers/__test__/createInvitation.spec.ts
@@ -68,10 +68,10 @@ describe("createInvitation handler", () => {
     expect(createError).not.toHaveBeenCalled();
     expect(reply.code).toHaveBeenCalledWith(422);
     expect(reply.send).toHaveBeenCalledWith({
-      statusCode: 422,
       code: ERROR_CODES.INVITATION_ALREADY_EXISTS,
       error: "Unprocessable Entity",
       message: "Invitation already exists for this email.",
+      statusCode: 422,
     });
   });
 

--- a/packages/user/src/model/invitations/handlers/createInvitation.ts
+++ b/packages/user/src/model/invitations/handlers/createInvitation.ts
@@ -53,16 +53,22 @@ const createInvitation = async (
   try {
     invitation = await service.create(invitationCreateInput);
   } catch (error: unknown) {
+    // Only duplicate pending invitations are handled here instead of
+    // `httpErrors.createError`. That throw path is formatted by the global error
+    // handler as an HttpError and includes extra properties (for example `name`)
+    // alongside `code`. This route keeps an explicit 422 body with
+    // `code`, `error`, `message`, and `statusCode` only for this conflict so
+    // consumers see a stable contract. Other `CustomError` codes from the
+    // invitation service still use the standard throw path below.
     if (
       error instanceof CustomError &&
       error.code === ERROR_CODES.INVITATION_ALREADY_EXISTS
     ) {
-      // Avoid throwing HttpError so Sentry (and similar) do not treat this as an exception.
       return reply.code(422).send({
-        statusCode: 422,
         code: error.code,
         error: "Unprocessable Entity",
         message: error.message,
+        statusCode: 422,
       });
     }
 

--- a/packages/user/src/model/invitations/handlers/createInvitation.ts
+++ b/packages/user/src/model/invitations/handlers/createInvitation.ts
@@ -1,3 +1,8 @@
+import { STATUS_CODES } from "node:http";
+
+import { CustomError } from "@prefabs.tech/fastify-error-handler";
+
+import { ERROR_CODES } from "../../../constants";
 import getInvitationService from "../../../lib/getInvitationService";
 import sendInvitation from "../../../lib/sendInvitation";
 
@@ -49,10 +54,24 @@ const createInvitation = async (
 
   try {
     invitation = await service.create(invitationCreateInput);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    throw server.httpErrors.createError(422, error.message, {
-      code: error.code,
+  } catch (error: unknown) {
+    if (
+      error instanceof CustomError &&
+      error.code === ERROR_CODES.INVITATION_ALREADY_EXISTS
+    ) {
+      // Avoid throwing HttpError so Sentry (and similar) do not treat this as an exception.
+      return reply.code(422).send({
+        statusCode: 422,
+        code: error.code,
+        error: STATUS_CODES[422],
+        message: error.message,
+      });
+    }
+
+    const err = error as { message?: string; code?: string };
+
+    throw server.httpErrors.createError(422, err.message ?? "Unknown error", {
+      code: err.code,
     });
   }
 

--- a/packages/user/src/model/invitations/handlers/createInvitation.ts
+++ b/packages/user/src/model/invitations/handlers/createInvitation.ts
@@ -1,5 +1,3 @@
-import { STATUS_CODES } from "node:http";
-
 import { CustomError } from "@prefabs.tech/fastify-error-handler";
 
 import { ERROR_CODES } from "../../../constants";
@@ -63,7 +61,7 @@ const createInvitation = async (
       return reply.code(422).send({
         statusCode: 422,
         code: error.code,
-        error: STATUS_CODES[422],
+        error: "Unprocessable Entity",
         message: error.message,
       });
     }

--- a/packages/user/src/model/invitations/handlers/createInvitation.ts
+++ b/packages/user/src/model/invitations/handlers/createInvitation.ts
@@ -1,6 +1,5 @@
 import { CustomError } from "@prefabs.tech/fastify-error-handler";
 
-import { ERROR_CODES } from "../../../constants";
 import getInvitationService from "../../../lib/getInvitationService";
 import sendInvitation from "../../../lib/sendInvitation";
 
@@ -53,28 +52,14 @@ const createInvitation = async (
   try {
     invitation = await service.create(invitationCreateInput);
   } catch (error: unknown) {
-    // Only duplicate pending invitations are handled here instead of
-    // `httpErrors.createError`. That throw path is formatted by the global error
-    // handler as an HttpError and includes extra properties (for example `name`)
-    // alongside `code`. This route keeps an explicit 422 body with
-    // `code`, `error`, `message`, and `statusCode` only for this conflict so
-    // consumers see a stable contract. Other `CustomError` codes from the
-    // invitation service still use the standard throw path below.
-    if (
-      error instanceof CustomError &&
-      error.code === ERROR_CODES.INVITATION_ALREADY_EXISTS
-    ) {
+    // CustomError: send a plain 422 body (code, message, statusCode) instead of
+    // createError, which the global handler augments with HttpError fields.
+    if (error instanceof CustomError) {
       return reply.code(422).send({
         code: error.code,
         error: "Unprocessable Entity",
         message: error.message,
         statusCode: 422,
-      });
-    }
-
-    if (error instanceof CustomError) {
-      throw server.httpErrors.createError(422, error.message, {
-        code: error.code,
       });
     }
 

--- a/packages/user/src/model/invitations/handlers/createInvitation.ts
+++ b/packages/user/src/model/invitations/handlers/createInvitation.ts
@@ -66,11 +66,17 @@ const createInvitation = async (
       });
     }
 
-    const err = error as { message?: string; code?: string };
+    if (error instanceof CustomError) {
+      throw server.httpErrors.createError(422, error.message, {
+        code: error.code,
+      });
+    }
 
-    throw server.httpErrors.createError(422, err.message ?? "Unknown error", {
-      code: err.code,
-    });
+    if (error instanceof Error) {
+      throw server.httpErrors.createError(422, error.message, {});
+    }
+
+    throw server.httpErrors.createError(422, "Unknown error", {});
   }
 
   if (invitation) {


### PR DESCRIPTION
## Return a consistent 422 response for invitation CustomErrors

### Tasks completed
- Updated `createInvitation` to handle service `CustomError`s by directly returning a 422 JSON response with `code`, `error`, `message`, and `statusCode`, instead of throwing `httpErrors.createError`.
- Kept non-`CustomError` failures on the throw path, with explicit handling for `Error` and unknown values.
- Added and updated `createInvitation` handler tests to verify the direct 422 response contract for both duplicate-invitation and other `CustomError` codes.