### PR TITLE
chore: pin handlebars 4.7.9 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "pnpm": {
     "overrides": {
+      "handlebars": "4.7.9",
       "@typescript-eslint/eslint-plugin": "8.58.0",
       "@typescript-eslint/parser": "8.58.0",
       "@typescript-eslint/typescript-estree": "8.58.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  typescript-eslint: 8.58.0
-  '@typescript-eslint/parser': 8.58.0
+  handlebars: 4.7.9
   '@typescript-eslint/eslint-plugin': 8.58.0
+  '@typescript-eslint/parser': 8.58.0
   '@typescript-eslint/typescript-estree': 8.58.0
   '@typescript-eslint/utils': 8.58.0
+  typescript-eslint: 8.58.0
 
 importers:
 
@@ -3677,8 +3678,8 @@ packages:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -8752,7 +8753,7 @@ snapshots:
   conventional-changelog-writer@8.2.0:
     dependencies:
       conventional-commits-filter: 5.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       meow: 13.2.0
       semver: 7.7.3
 
@@ -9915,7 +9916,7 @@ snapshots:
       - supports-color
     optional: true
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
## chore: pin handlebars 4.7.9 via pnpm override

This PR targets `pre-upgrade` so it stays a single-commit review on top of that branch (the same change would bundle ~18 unrelated commits if opened against `main`).

### Tasks completed
- Added a root `pnpm.overrides` entry to pin `handlebars` to `4.7.9`.
- Refreshed `pnpm-lock.yaml` so transitive consumers (for example `conventional-changelog-writer`) resolve to the pinned version.