### PR TITLE
feat(error-handler): add domainErrorStatusMap for HTTP status by error name

### DIFF
--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -8,7 +8,7 @@
 
 2. **Adds `ErrorResponse` JSON schema** — registers the `ErrorResponse` schema (`$id: "ErrorResponse"`) with Fastify so routes can reference it in response schemas.
 
-3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional registration option (empty map when omitted).
+3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional registration option (empty map when omitted). Each configured status code must be an integer in **`100`–`599`** or registration throws.
 
 ## Error Handler
 
@@ -18,7 +18,7 @@
 
 6. **HttpError branch** — errors that are `instanceof HttpError` (thrown via `fastify.httpErrors.*`) respond with the original status code, HTTP status text in `error`, and the original message and name.
 
-7. **Optional `domainErrorStatusMap` branch** — when `error.name` exists as a key in the configured map, the error responds with that HTTP status and `ErrorResponse` fields aligned with the `HttpError` path (including `CustomError.code` when applicable); logging follows the same status-range rules as **severity-based logging** below.
+7. **Optional `domainErrorStatusMap` branch** — when `error.name` exists as a key in the configured map, the error responds with that HTTP status, `error` (HTTP status text), and (when `stackTrace: true`) `message`, `name`, and `code` aligned with **item 9** below. When `stackTrace: false`, **`message`**, **`name`**, and **`code`** use the same safe values as **item 10** (plain `Error` vs `CustomError`). Logging follows the same status-range rules as **severity-based logging** below.
 
 8. **Non-mapped non-HttpError branch** — all other plain `Error`, `CustomError`, and subclass errors that are not matched by item 7 respond with status `500`.
 
@@ -49,10 +49,10 @@
 17. **Consistent `ErrorResponse` shape** — every error response conforms to:
     ```typescript
     {
-      code?: string;              // error code (HttpErrors / mapped CustomErrors: from .code; masked unmapped non-HttpErrors: "INTERNAL_SERVER_ERROR")
+      code?: string;              // error code (HttpErrors: from .code; mapped / unmapped non-HttpErrors: see items 7, 9–10 for stackTrace)
       error?: string;             // HTTP status text (HttpErrors and mapped domain errors)
-      message: string;            // error message (masked for unmapped non-HttpErrors when stackTrace: false)
-      name: string;               // error class name (masked to "Error" for unmapped non-HttpErrors when stackTrace: false)
+      message: string;            // error message (masked per item 7 / 10 when stackTrace: false)
+      name: string;               // error class name (masked per item 7 / 10 when stackTrace: false)
       stack?: StackTracey.Entry[] // parsed stack frames (only when stackTrace: true)
       statusCode: number;         // HTTP status code
     }
@@ -60,7 +60,7 @@
 
 ## Exports
 
-18. **`errorHandler` function** — exported standalone for use outside the plugin registration context.
+18. **`errorHandler` function** — exported standalone for use outside the plugin registration context; the `Fastify` instance must still provide **`stackTrace`** and **`domainErrorStatusMap`** (e.g. empty `new Map()` when unused) the same way the plugin decorates them, or lookups will throw.
 
 19. **`CustomError` class** — base class for application errors with a `code` string field.
 

--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -8,7 +8,7 @@
 
 2. **Adds `ErrorResponse` JSON schema** — registers the `ErrorResponse` schema (`$id: "ErrorResponse"`) with Fastify so routes can reference it in response schemas.
 
-3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional registration option (empty map when omitted). Each configured status code must be an integer in **`400`–`599`** or registration throws.
+3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional app-provided **`ReadonlyMap<string, number>`** (validated copy; empty map when omitted). Each configured status code must be an integer in **`400`–`599`** or registration throws.
 
 ## Error Handler
 

--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -8,7 +8,7 @@
 
 2. **Adds `ErrorResponse` JSON schema** — registers the `ErrorResponse` schema (`$id: "ErrorResponse"`) with Fastify so routes can reference it in response schemas.
 
-3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional registration option (empty map when omitted). Each configured status code must be an integer in **`100`–`599`** or registration throws.
+3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional registration option (empty map when omitted). Each configured status code must be an integer in **`400`–`599`** or registration throws.
 
 ## Error Handler
 

--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -18,13 +18,13 @@
 
 6. **HttpError branch** — errors that are `instanceof HttpError` (thrown via `fastify.httpErrors.*`) respond with the original status code, HTTP status text in `error`, and the original message and name.
 
-7. **Optional `domainErrorStatusMap` branch** — when `error.name` exists as a key in the configured map, the error responds with that HTTP status, `error` (HTTP status text), and (when `stackTrace: true`) `message`, `name`, and `code` aligned with **item 9** below. When `stackTrace: false`, **`message`**, **`name`**, and **`code`** use the same safe values as **item 10** (plain `Error` vs `CustomError`). Logging follows the same status-range rules as **severity-based logging** below.
+7. **Optional `domainErrorStatusMap` branch** — when `error.name` exists as a key in the configured map, the error responds with that HTTP status, `error` (HTTP status text), `message`, `name`, and (for `CustomError`) `code`; **`stackTrace`** only adds the parsed `stack` field (it does not mask or replace these fields for mapped errors). Logging follows the same status-range rules as **severity-based logging** below.
 
 8. **Non-mapped non-HttpError branch** — all other plain `Error`, `CustomError`, and subclass errors that are not matched by item 7 respond with status `500`.
 
 9. **`CustomError` code extraction (unmapped)** — when the thrown error is `instanceof CustomError` and not handled by item 7, its `.code` is used in the response (only when `stackTrace: true`; otherwise `"INTERNAL_SERVER_ERROR"` is used).
 
-10. **Error detail masking (`stackTrace: false`, unmapped)** — for non-HttpErrors not handled by item 7, the response replaces message, name, and code with safe generic values:
+10. **Error detail masking (`stackTrace: false`, unmapped only)** — for non-HttpErrors not handled by item 7, the response replaces message, name, and code with safe generic values:
    - Plain `Error`: message → `"Server error, please contact support"`, name → `"Error"`, code → `"INTERNAL_SERVER_ERROR"`
    - `CustomError`: message → `"Server has an error that is not handled, please contact support"`, name → `"Error"`, code → `"INTERNAL_SERVER_ERROR"`
 
@@ -49,10 +49,10 @@
 17. **Consistent `ErrorResponse` shape** — every error response conforms to:
     ```typescript
     {
-      code?: string;              // error code (HttpErrors: from .code; mapped / unmapped non-HttpErrors: see items 7, 9–10 for stackTrace)
+      code?: string;              // error code (HttpErrors / mapped CustomError: from .code; unmapped: see items 9–10)
       error?: string;             // HTTP status text (HttpErrors and mapped domain errors)
-      message: string;            // error message (masked per item 7 / 10 when stackTrace: false)
-      name: string;               // error class name (masked per item 7 / 10 when stackTrace: false)
+      message: string;            // error message (masked for unmapped non-HttpErrors when stackTrace: false; mapped errors use the thrown message)
+      name: string;               // error class name (masked for unmapped non-HttpErrors when stackTrace: false; mapped errors use the thrown name)
       stack?: StackTracey.Entry[] // parsed stack frames (only when stackTrace: true)
       statusCode: number;         // HTTP status code
     }
@@ -60,7 +60,7 @@
 
 ## Exports
 
-18. **`errorHandler` function** — exported standalone for use outside the plugin registration context; the `Fastify` instance must still provide **`stackTrace`** and **`domainErrorStatusMap`** (e.g. empty `new Map()` when unused) the same way the plugin decorates them, or lookups will throw.
+18. **`errorHandler` function** — exported standalone for use outside the plugin registration context. The instance should still provide **`stackTrace`** (decorator). **`domainErrorStatusMap`** is optional: if absent, the domain-map branch is skipped (same as an empty map).
 
 19. **`CustomError` class** — base class for application errors with a `code` string field.
 

--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -8,7 +8,7 @@
 
 2. **Adds `ErrorResponse` JSON schema** — registers the `ErrorResponse` schema (`$id: "ErrorResponse"`) with Fastify so routes can reference it in response schemas.
 
-3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional app-provided **`ReadonlyMap<string, number>`** (validated copy; empty map when omitted). Each configured status code must be an integer in **`400`–`599`** or registration throws.
+3. **`stackTrace` and `domainErrorStatusMap` options** — plugin options control stack visibility and optional domain status mapping (`ReadonlyMap<string, number>`). `domainErrorStatusMap` is validated at registration and copied internally (empty map when omitted). Each configured status code must be an integer in **`400`–`599`** or registration throws.
 
 ## Error Handler
 
@@ -60,7 +60,7 @@
 
 ## Exports
 
-18. **`errorHandler` function** — exported standalone for use outside the plugin registration context. The instance should still provide **`stackTrace`** (decorator). **`domainErrorStatusMap`** is optional: if absent, the domain-map branch is skipped (same as an empty map).
+18. **`errorHandler` function** — exported standalone for use outside the plugin registration context. Pass **`stackTrace`** and optional **`domainErrorStatusMap`** through the 4th argument (`ErrorHandlerOptions`). If `domainErrorStatusMap` is absent, the domain-map branch is skipped (same as an empty map).
 
 19. **`CustomError` class** — base class for application errors with a `code` string field.
 

--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -8,7 +8,7 @@
 
 2. **Adds `ErrorResponse` JSON schema** — registers the `ErrorResponse` schema (`$id: "ErrorResponse"`) with Fastify so routes can reference it in response schemas.
 
-3. **`stackTrace` decorator** — decorates the Fastify instance with `fastify.stackTrace: boolean`, defaulting to `false`.
+3. **`stackTrace` and `domainErrorStatusMap` decorators** — decorates the Fastify instance with `fastify.stackTrace: boolean` (default `false`) and `fastify.domainErrorStatusMap: Map<string, number>` built from the optional registration option (empty map when omitted).
 
 ## Error Handler
 
@@ -18,17 +18,17 @@
 
 6. **HttpError branch** — errors that are `instanceof HttpError` (thrown via `fastify.httpErrors.*`) respond with the original status code, HTTP status text in `error`, and the original message and name.
 
-7. **Non-HttpError branch** — all other errors (plain `Error`, `CustomError`, subclasses) always respond with status `500`.
+7. **Optional `domainErrorStatusMap` branch** — when `error.name` exists as a key in the configured map, the error responds with that HTTP status and `ErrorResponse` fields aligned with the `HttpError` path (including `CustomError.code` when applicable); logging follows the same status-range rules as **severity-based logging** below.
 
-8. **`CustomError` code extraction** — when the thrown error is `instanceof CustomError`, its `.code` is used in the response (only when `stackTrace: true`; otherwise `"INTERNAL_SERVER_ERROR"` is used).
+8. **Non-mapped non-HttpError branch** — all other plain `Error`, `CustomError`, and subclass errors that are not matched by item 7 respond with status `500`.
 
-9. **Error detail masking** (`stackTrace: false`) — for non-HttpErrors, the response replaces message, name, and code with safe generic values:
+9. **`CustomError` code extraction (unmapped)** — when the thrown error is `instanceof CustomError` and not handled by item 7, its `.code` is used in the response (only when `stackTrace: true`; otherwise `"INTERNAL_SERVER_ERROR"` is used).
+
+10. **Error detail masking (`stackTrace: false`, unmapped)** — for non-HttpErrors not handled by item 7, the response replaces message, name, and code with safe generic values:
    - Plain `Error`: message → `"Server error, please contact support"`, name → `"Error"`, code → `"INTERNAL_SERVER_ERROR"`
    - `CustomError`: message → `"Server has an error that is not handled, please contact support"`, name → `"Error"`, code → `"INTERNAL_SERVER_ERROR"`
 
-10. **Severity-based logging for HttpErrors** — `5xx` logged at `error` level; `4xx` logged at `info` level; below `400` logged at `error` level.
-
-11. **Non-HttpError always logged at `error` level** — regardless of `stackTrace` setting.
+11. **Severity-based logging** — `HttpError` instances and **`domainErrorStatusMap`** matches use status ranges (`5xx` logged at `error` level; `4xx` at `info`; below `400` at `error`). Non-mapped non-HttpErrors log at `error` level regardless of `stackTrace`.
 
 ## Stack Traces
 
@@ -49,10 +49,10 @@
 17. **Consistent `ErrorResponse` shape** — every error response conforms to:
     ```typescript
     {
-      code?: string;              // error code (HttpErrors: from .code; non-HttpErrors: custom or "INTERNAL_SERVER_ERROR")
-      error?: string;             // HTTP status text (HttpErrors only)
-      message: string;            // error message (masked for non-HttpErrors when stackTrace: false)
-      name: string;               // error class name (masked to "Error" for non-HttpErrors when stackTrace: false)
+      code?: string;              // error code (HttpErrors / mapped CustomErrors: from .code; masked unmapped non-HttpErrors: "INTERNAL_SERVER_ERROR")
+      error?: string;             // HTTP status text (HttpErrors and mapped domain errors)
+      message: string;            // error message (masked for unmapped non-HttpErrors when stackTrace: false)
+      name: string;               // error class name (masked to "Error" for unmapped non-HttpErrors when stackTrace: false)
       stack?: StackTracey.Entry[] // parsed stack frames (only when stackTrace: true)
       statusCode: number;         // HTTP status code
     }

--- a/packages/error-handler/GUIDE.md
+++ b/packages/error-handler/GUIDE.md
@@ -89,9 +89,9 @@ fastify.get("/forbidden", async () => {
 
 ### Domain error status map (`domainErrorStatusMap`)
 
-After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured `statusCode` and `error` (HTTP status text). Map values must be **integers from `100` to `599`** or plugin registration throws.
+After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured `statusCode` and `error` (HTTP status text), and include the thrown **`message`** and **`name`** (and **`code`** when the error is a **`CustomError`**) regardless of **`stackTrace`**; **`stackTrace: true`** only adds the parsed **`stack`** field when present. Map values must be **integers from `100` to `599`** or plugin registration throws. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
 
-When **`stackTrace: true`**, `message` and `name` come from the error, and `code` follows the same rules as unmapped `CustomError` / plain `Error` responses (see **Non-HttpError handling — error masking (unmapped)** below for the `stackTrace: true` case). When **`stackTrace: false`** (the default), `message`, `name`, and `code` are masked the same way as unmapped non-`HttpError` errors (generic messages, `name` → `"Error"`, `code` → `"INTERNAL_SERVER_ERROR"`). Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
+**Standalone `errorHandler`:** if you reuse the exported handler without the plugin, decorate **`stackTrace`** as the plugin does; **`domainErrorStatusMap`** is optional—omit it or pass an empty `Map` if you do not use the map.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {

--- a/packages/error-handler/GUIDE.md
+++ b/packages/error-handler/GUIDE.md
@@ -89,7 +89,7 @@ fastify.get("/forbidden", async () => {
 
 ### Domain error status map (`domainErrorStatusMap`)
 
-After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured `statusCode` and `error` (HTTP status text), and include the thrown **`message`** and **`name`** (and **`code`** when the error is a **`CustomError`**) regardless of **`stackTrace`**; **`stackTrace: true`** only adds the parsed **`stack`** field when present. Map values must be **integers from `100` to `599`** or plugin registration throws. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
+After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured `statusCode` and `error` (HTTP status text), and include the thrown **`message`** and **`name`** (and **`code`** when the error is a **`CustomError`**) regardless of **`stackTrace`**; **`stackTrace: true`** only adds the parsed **`stack`** field when present. Map values must be **integers from `400` to `599`** or plugin registration throws. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
 
 **Standalone `errorHandler`:** if you reuse the exported handler without the plugin, decorate **`stackTrace`** as the plugin does; **`domainErrorStatusMap`** is optional—omit it or pass an empty `Map` if you do not use the map.
 

--- a/packages/error-handler/GUIDE.md
+++ b/packages/error-handler/GUIDE.md
@@ -91,7 +91,7 @@ fastify.get("/forbidden", async () => {
 
 After `HttpError` handling, non-`HttpError` errors whose **`name`** appears as a key in the app-provided **`domainErrorStatusMap`** (`Map<string, number>`) respond with the configured `statusCode` and `error` (HTTP status text), and include the thrown **`message`** and **`name`** (and **`code`** when the error is a **`CustomError`**) regardless of **`stackTrace`**; **`stackTrace: true`** only adds the parsed **`stack`** field when present. Map values must be **integers from `400` to `599`** or plugin registration throws. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
 
-**Standalone `errorHandler`:** if you reuse the exported handler without the plugin, decorate **`stackTrace`** as the plugin does; **`domainErrorStatusMap`** is optional—omit it or pass an empty `Map` if you do not use the map.
+**Standalone `errorHandler`:** if you reuse the exported handler without the plugin, pass **`stackTrace`** and optional **`domainErrorStatusMap`** via the handler's 4th argument (`ErrorHandlerOptions`).
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {
@@ -127,20 +127,12 @@ The log level depends on the error's status code:
 
 Non-HttpErrors are logged at `error` level unless handled via **`domainErrorStatusMap`** (then logging follows status ranges like `HttpError`).
 
-### `stackTrace` option and decorator
+### `stackTrace` option
 
 Controls whether parsed stack frames appear in error responses. Defaults to `false`.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, { stackTrace: true });
-```
-
-The current value is accessible at runtime via `fastify.stackTrace`:
-
-```typescript
-fastify.get("/debug", async () => {
-  return { stackTraceEnabled: fastify.stackTrace };
-});
 ```
 
 When enabled, error responses include a `stack` array of `StackTracey.Entry` objects (file, line, column, callee). The field is omitted if the error has no `.stack` property.
@@ -205,7 +197,10 @@ import { errorHandler } from "@prefabs.tech/fastify-error-handler";
 
 fastify.setErrorHandler((error, request, reply) => {
   // custom pre-processing...
-  return errorHandler(error, request, reply);
+  return errorHandler(error, request, reply, {
+    stackTrace: true,
+    domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
+  });
 });
 ```
 

--- a/packages/error-handler/GUIDE.md
+++ b/packages/error-handler/GUIDE.md
@@ -89,7 +89,9 @@ fastify.get("/forbidden", async () => {
 
 ### Domain error status map (`domainErrorStatusMap`)
 
-After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured status and the same general `ErrorResponse` shape as `HttpError` responses: `statusCode`, `error` (HTTP status text), `message`, `name`, and optional `code` when the error is a `CustomError`. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
+After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured `statusCode` and `error` (HTTP status text). Map values must be **integers from `100` to `599`** or plugin registration throws.
+
+When **`stackTrace: true`**, `message` and `name` come from the error, and `code` follows the same rules as unmapped `CustomError` / plain `Error` responses (see **Non-HttpError handling — error masking (unmapped)** below for the `stackTrace: true` case). When **`stackTrace: false`** (the default), `message`, `name`, and `code` are masked the same way as unmapped non-`HttpError` errors (generic messages, `name` → `"Error"`, `code` → `"INTERNAL_SERVER_ERROR"`). Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {

--- a/packages/error-handler/GUIDE.md
+++ b/packages/error-handler/GUIDE.md
@@ -33,7 +33,7 @@ const fastify = Fastify();
 await fastify.register(errorHandlerPlugin, {
   stackTrace: false, // optional, default: false
   preErrorHandler: undefined, // optional
-  domainErrorStatusMap: undefined, // optional: error.name → HTTP status (e.g. { UnprocessableEntityError: 422 })
+  domainErrorStatusMap: undefined, // optional: Map<error.name, HTTP status> (e.g. new Map([["UnprocessableEntityError", 422]]))
 });
 ```
 
@@ -89,15 +89,13 @@ fastify.get("/forbidden", async () => {
 
 ### Domain error status map (`domainErrorStatusMap`)
 
-After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured `statusCode` and `error` (HTTP status text), and include the thrown **`message`** and **`name`** (and **`code`** when the error is a **`CustomError`**) regardless of **`stackTrace`**; **`stackTrace: true`** only adds the parsed **`stack`** field when present. Map values must be **integers from `400` to `599`** or plugin registration throws. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
+After `HttpError` handling, non-`HttpError` errors whose **`name`** appears as a key in the app-provided **`domainErrorStatusMap`** (`Map<string, number>`) respond with the configured `statusCode` and `error` (HTTP status text), and include the thrown **`message`** and **`name`** (and **`code`** when the error is a **`CustomError`**) regardless of **`stackTrace`**; **`stackTrace: true`** only adds the parsed **`stack`** field when present. Map values must be **integers from `400` to `599`** or plugin registration throws. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
 
 **Standalone `errorHandler`:** if you reuse the exported handler without the plugin, decorate **`stackTrace`** as the plugin does; **`domainErrorStatusMap`** is optional—omit it or pass an empty `Map` if you do not use the map.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {
-  domainErrorStatusMap: {
-    UnprocessableEntityError: 422,
-  },
+  domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
 });
 
 fastify.get("/validate", async () => {

--- a/packages/error-handler/GUIDE.md
+++ b/packages/error-handler/GUIDE.md
@@ -33,6 +33,7 @@ const fastify = Fastify();
 await fastify.register(errorHandlerPlugin, {
   stackTrace: false, // optional, default: false
   preErrorHandler: undefined, // optional
+  domainErrorStatusMap: undefined, // optional: error.name → HTTP status (e.g. { UnprocessableEntityError: 422 })
 });
 ```
 
@@ -86,9 +87,27 @@ fastify.get("/forbidden", async () => {
 });
 ```
 
-### Non-HttpError handling — error masking
+### Domain error status map (`domainErrorStatusMap`)
 
-All non-`HttpError` errors (plain `Error`, `CustomError`, and any subclass) always respond with status `500`. When `stackTrace: false` (the default), internal details are masked:
+After `HttpError` handling, non-`HttpError` errors whose **`name`** appears in **`domainErrorStatusMap`** respond with the configured status and the same general `ErrorResponse` shape as `HttpError` responses: `statusCode`, `error` (HTTP status text), `message`, `name`, and optional `code` when the error is a `CustomError`. Logging follows the same rules as `HttpError` (5xx → `error`, 4xx → `info`, below 400 → `error`).
+
+```typescript
+await fastify.register(errorHandlerPlugin, {
+  domainErrorStatusMap: {
+    UnprocessableEntityError: 422,
+  },
+});
+
+fastify.get("/validate", async () => {
+  const err = new Error("Invalid payload");
+  err.name = "UnprocessableEntityError";
+  throw err;
+});
+```
+
+### Non-HttpError handling — error masking (unmapped)
+
+Non-`HttpError` errors that are **not** listed in **`domainErrorStatusMap`** (plain `Error`, `CustomError`, and any subclass) respond with status `500`. When `stackTrace: false` (the default), internal details are masked:
 
 - `message` → `"Server error, please contact support"`
 - `name` → `"Error"`
@@ -106,7 +125,7 @@ The log level depends on the error's status code:
 - `4xx` → logged at `info` level
 - below `400` → logged at `error` level
 
-Non-HttpErrors are always logged at `error` level regardless of `stackTrace` setting.
+Non-HttpErrors are logged at `error` level unless handled via **`domainErrorStatusMap`** (then logging follows status ranges like `HttpError`).
 
 ### `stackTrace` option and decorator
 

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -26,7 +26,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **`stackTrace` decorator** — `fastify.stackTrace` (boolean) reflects the active setting, accessible to other plugins and hooks
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
-- **`domainErrorStatusMap`** — optional map from `error.name` to an HTTP status integer **`100`–`599`** (invalid entries fail at registration); mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
+- **`domainErrorStatusMap`** — optional map from `error.name` to an HTTP status integer **`400`–`599`** (invalid entries fail at registration); mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
 
 → [Full feature list](FEATURES.md) · [Developer guide](GUIDE.md)
 
@@ -96,7 +96,7 @@ await fastify.listen({ port: 3000, host: "0.0.0.0" });
 
 ### Domain status codes
 
-Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**, and each value must be an integer **`100`–`599`**. Mapped responses include the thrown message and name (and `CustomError` codes); generic masking applies only to **unmapped** internal errors when **`stackTrace`** is off.
+Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**, and each value must be an integer **`400`–`599`**. Mapped responses include the thrown message and name (and `CustomError` codes); generic masking applies only to **unmapped** internal errors when **`stackTrace`** is off.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -23,7 +23,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **Safe message masking** — 5xx errors hide implementation details behind generic messages by default; `stackTrace: true` disables masking for development
 - **`preErrorHandler` hook** — run custom logic (e.g. SuperTokens, Passport) before the default handler; short-circuits if your handler sends the reply, swallows exceptions otherwise
 - **`CustomError` base class** — extend it to create domain errors with a custom `code` field; subclasses are handled safely
-- **`stackTrace` decorator** — `fastify.stackTrace` (boolean) reflects the active setting, accessible to other plugins and hooks
+- **`stackTrace` option** — controls whether parsed stack frames are included in error responses
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
 - **`domainErrorStatusMap`** — optional app-provided `Map<string, number>` from `error.name` to an HTTP status integer **`400`–`599`** (invalid entries fail at registration); the plugin stores a validated copy. Mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
@@ -101,6 +101,21 @@ Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses
 ```typescript
 await fastify.register(errorHandlerPlugin, {
   domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
+});
+```
+
+### Standalone `errorHandler` usage
+
+If you use the exported `errorHandler` directly (without registering the plugin), pass options as the 4th argument:
+
+```typescript
+import { errorHandler } from "@prefabs.tech/fastify-error-handler";
+
+fastify.setErrorHandler((error, request, reply) => {
+  return errorHandler(error, request, reply, {
+    stackTrace: true,
+    domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
+  });
 });
 ```
 

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -26,7 +26,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **`stackTrace` decorator** — `fastify.stackTrace` (boolean) reflects the active setting, accessible to other plugins and hooks
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
-- **`domainErrorStatusMap`** — optional map from `error.name` to an HTTP status integer **`100`–`599`** (invalid entries fail at registration); uses the mapped status and status text with the same **`stackTrace`** masking rules as other non-`HttpError` errors
+- **`domainErrorStatusMap`** — optional map from `error.name` to an HTTP status integer **`100`–`599`** (invalid entries fail at registration); mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
 
 → [Full feature list](FEATURES.md) · [Developer guide](GUIDE.md)
 
@@ -96,7 +96,7 @@ await fastify.listen({ port: 3000, host: "0.0.0.0" });
 
 ### Domain status codes
 
-Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**, and each value must be an integer **`100`–`599`**. With **`stackTrace: false`** (default), response bodies use the same generic masking as other internal errors while preserving the mapped status code.
+Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**, and each value must be an integer **`100`–`599`**. Mapped responses include the thrown message and name (and `CustomError` codes); generic masking applies only to **unmapped** internal errors when **`stackTrace`** is off.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -26,7 +26,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **`stackTrace` decorator** — `fastify.stackTrace` (boolean) reflects the active setting, accessible to other plugins and hooks
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
-- **`domainErrorStatusMap`** — optional map from `error.name` to HTTP status (for domain-specific subclasses or named errors such as validation failures returning `422`), formatted like `HttpError` responses
+- **`domainErrorStatusMap`** — optional map from `error.name` to an HTTP status integer **`100`–`599`** (invalid entries fail at registration); uses the mapped status and status text with the same **`stackTrace`** masking rules as other non-`HttpError` errors
 
 → [Full feature list](FEATURES.md) · [Developer guide](GUIDE.md)
 
@@ -96,7 +96,7 @@ await fastify.listen({ port: 3000, host: "0.0.0.0" });
 
 ### Domain status codes
 
-Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**.
+Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**, and each value must be an integer **`100`–`599`**. With **`stackTrace: false`** (default), response bodies use the same generic masking as other internal errors while preserving the mapped status code.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -26,7 +26,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **`stackTrace` decorator** — `fastify.stackTrace` (boolean) reflects the active setting, accessible to other plugins and hooks
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
-- **`domainErrorStatusMap`** — optional map from `error.name` to an HTTP status integer **`400`–`599`** (invalid entries fail at registration); mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
+- **`domainErrorStatusMap`** — optional app-provided `Map<string, number>` from `error.name` to an HTTP status integer **`400`–`599`** (invalid entries fail at registration); the plugin stores a validated copy. Mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
 
 → [Full feature list](FEATURES.md) · [Developer guide](GUIDE.md)
 
@@ -96,13 +96,11 @@ await fastify.listen({ port: 3000, host: "0.0.0.0" });
 
 ### Domain status codes
 
-Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**, and each value must be an integer **`400`–`599`**. Mapped responses include the thrown message and name (and `CustomError` codes); generic masking applies only to **unmapped** internal errors when **`stackTrace`** is off.
+Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — pass a **`Map`** whose keys match thrown **`error.name`**; each value must be an integer **`400`–`599`**. Mapped responses include the thrown message and name (and `CustomError` codes); generic masking applies only to **unmapped** internal errors when **`stackTrace`** is off.
 
 ```typescript
 await fastify.register(errorHandlerPlugin, {
-  domainErrorStatusMap: {
-    UnprocessableEntityError: 422,
-  },
+  domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
 });
 ```
 

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -26,6 +26,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **`stackTrace` decorator** — `fastify.stackTrace` (boolean) reflects the active setting, accessible to other plugins and hooks
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
+- **`domainErrorStatusMap`** — optional map from `error.name` to HTTP status (for domain-specific subclasses or named errors such as validation failures returning `422`), formatted like `HttpError` responses
 
 → [Full feature list](FEATURES.md) · [Developer guide](GUIDE.md)
 
@@ -91,6 +92,18 @@ fastify.get("/example", async () => {
 });
 
 await fastify.listen({ port: 3000, host: "0.0.0.0" });
+```
+
+### Domain status codes
+
+Use **`domainErrorStatusMap`** when domain errors should return non-500 statuses — keys must match thrown **`error.name`**.
+
+```typescript
+await fastify.register(errorHandlerPlugin, {
+  domainErrorStatusMap: {
+    UnprocessableEntityError: 422,
+  },
+});
 ```
 
 ## Installation

--- a/packages/error-handler/src/__test__/domainStatusMap.test.ts
+++ b/packages/error-handler/src/__test__/domainStatusMap.test.ts
@@ -13,7 +13,7 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
 
   it("responds with mapped status when error.name matches", async () => {
     fastify = await buildFastify({
-      domainErrorStatusMap: { UnprocessableEntityError: 422 },
+      domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
     });
     fastify.get("/test", async () => {
       const err = new Error("validation failed");
@@ -40,7 +40,7 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
     }
 
     fastify = await buildFastify({
-      domainErrorStatusMap: { UnprocessableEntityError: 422 },
+      domainErrorStatusMap: new Map([["UnprocessableEntityError", 422]]),
     });
     fastify.get("/test", async () => {
       throw new UnprocessableEntityError("bad");
@@ -54,7 +54,7 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
 
   it("includes stack when stackTrace is true", async () => {
     fastify = await buildFastify({
-      domainErrorStatusMap: { MappedError: 409 },
+      domainErrorStatusMap: new Map([["MappedError", 409]]),
       stackTrace: true,
     });
     fastify.get("/test", async () => {
@@ -77,10 +77,10 @@ describe("errorHandlerPlugin — domainErrorStatusMap logging", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fastify = Fastify({ loggerInstance: logSpy as any });
     await fastify.register(errorHandlerPlugin, {
-      domainErrorStatusMap: {
-        ClientErr: 422,
-        ServerMapped: 503,
-      },
+      domainErrorStatusMap: new Map([
+        ["ClientErr", 422],
+        ["ServerMapped", 503],
+      ]),
     });
     fastify.get("/422", async () => {
       const err = new Error("x");

--- a/packages/error-handler/src/__test__/domainStatusMap.test.ts
+++ b/packages/error-handler/src/__test__/domainStatusMap.test.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import Fastify from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,7 +11,7 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
 
   afterEach(async () => await fastify.close());
 
-  it("responds with mapped status when error.name matches", async () => {
+  it("responds with mapped status and masks details when stackTrace is false", async () => {
     fastify = await buildFastify({
       domainErrorStatusMap: { UnprocessableEntityError: 422 },
     });
@@ -26,12 +25,33 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
     expect(res.statusCode).toBe(422);
     const body = res.json();
     expect(body.statusCode).toBe(422);
-    expect(body.message).toBe("validation failed");
-    expect(body.name).toBe("UnprocessableEntityError");
+    expect(body.message).toBe("Server error, please contact support");
+    expect(body.name).toBe("Error");
+    expect(body.code).toBe("INTERNAL_SERVER_ERROR");
     expect(body.error).toBe("Unprocessable Entity");
   });
 
-  it("includes CustomError.code on mapped responses", async () => {
+  it("exposes message and name when stackTrace is true", async () => {
+    fastify = await buildFastify({
+      domainErrorStatusMap: { UnprocessableEntityError: 422 },
+      stackTrace: true,
+    });
+    fastify.get("/test", async () => {
+      const err = new Error("validation failed");
+      err.name = "UnprocessableEntityError";
+      throw err;
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.message).toBe("validation failed");
+    expect(body.name).toBe("UnprocessableEntityError");
+    expect(body.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(body.error).toBe("Unprocessable Entity");
+  });
+
+  it("masks CustomError like unmapped errors when stackTrace is false", async () => {
     class UnprocessableEntityError extends CustomError {
       constructor(message: string) {
         super(message, "UNPROCESSABLE_ENTITY");
@@ -41,6 +61,32 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
 
     fastify = await buildFastify({
       domainErrorStatusMap: { UnprocessableEntityError: 422 },
+    });
+    fastify.get("/test", async () => {
+      throw new UnprocessableEntityError("bad");
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(body.message).toBe(
+      "Server has an error that is not handled, please contact support",
+    );
+    expect(body.name).toBe("Error");
+  });
+
+  it("includes CustomError.code when stackTrace is true", async () => {
+    class UnprocessableEntityError extends CustomError {
+      constructor(message: string) {
+        super(message, "UNPROCESSABLE_ENTITY");
+        this.name = "UnprocessableEntityError";
+      }
+    }
+
+    fastify = await buildFastify({
+      domainErrorStatusMap: { UnprocessableEntityError: 422 },
+      stackTrace: true,
     });
     fastify.get("/test", async () => {
       throw new UnprocessableEntityError("bad");

--- a/packages/error-handler/src/__test__/domainStatusMap.test.ts
+++ b/packages/error-handler/src/__test__/domainStatusMap.test.ts
@@ -11,7 +11,7 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
 
   afterEach(async () => await fastify.close());
 
-  it("responds with mapped status and masks details when stackTrace is false", async () => {
+  it("responds with mapped status when error.name matches", async () => {
     fastify = await buildFastify({
       domainErrorStatusMap: { UnprocessableEntityError: 422 },
     });
@@ -25,33 +25,13 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
     expect(res.statusCode).toBe(422);
     const body = res.json();
     expect(body.statusCode).toBe(422);
-    expect(body.message).toBe("Server error, please contact support");
-    expect(body.name).toBe("Error");
-    expect(body.code).toBe("INTERNAL_SERVER_ERROR");
-    expect(body.error).toBe("Unprocessable Entity");
-  });
-
-  it("exposes message and name when stackTrace is true", async () => {
-    fastify = await buildFastify({
-      domainErrorStatusMap: { UnprocessableEntityError: 422 },
-      stackTrace: true,
-    });
-    fastify.get("/test", async () => {
-      const err = new Error("validation failed");
-      err.name = "UnprocessableEntityError";
-      throw err;
-    });
-
-    const res = await fastify.inject({ method: "GET", url: "/test" });
-    expect(res.statusCode).toBe(422);
-    const body = res.json();
     expect(body.message).toBe("validation failed");
     expect(body.name).toBe("UnprocessableEntityError");
-    expect(body.code).toBe("INTERNAL_SERVER_ERROR");
     expect(body.error).toBe("Unprocessable Entity");
+    expect(body.code).toBeUndefined();
   });
 
-  it("masks CustomError like unmapped errors when stackTrace is false", async () => {
+  it("includes CustomError.code on mapped responses", async () => {
     class UnprocessableEntityError extends CustomError {
       constructor(message: string) {
         super(message, "UNPROCESSABLE_ENTITY");
@@ -61,32 +41,6 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
 
     fastify = await buildFastify({
       domainErrorStatusMap: { UnprocessableEntityError: 422 },
-    });
-    fastify.get("/test", async () => {
-      throw new UnprocessableEntityError("bad");
-    });
-
-    const res = await fastify.inject({ method: "GET", url: "/test" });
-    expect(res.statusCode).toBe(422);
-    const body = res.json();
-    expect(body.code).toBe("INTERNAL_SERVER_ERROR");
-    expect(body.message).toBe(
-      "Server has an error that is not handled, please contact support",
-    );
-    expect(body.name).toBe("Error");
-  });
-
-  it("includes CustomError.code when stackTrace is true", async () => {
-    class UnprocessableEntityError extends CustomError {
-      constructor(message: string) {
-        super(message, "UNPROCESSABLE_ENTITY");
-        this.name = "UnprocessableEntityError";
-      }
-    }
-
-    fastify = await buildFastify({
-      domainErrorStatusMap: { UnprocessableEntityError: 422 },
-      stackTrace: true,
     });
     fastify.get("/test", async () => {
       throw new UnprocessableEntityError("bad");
@@ -95,6 +49,7 @@ describe("errorHandlerPlugin — domainErrorStatusMap", () => {
     const res = await fastify.inject({ method: "GET", url: "/test" });
     expect(res.statusCode).toBe(422);
     expect(res.json().code).toBe("UNPROCESSABLE_ENTITY");
+    expect(res.json().message).toBe("bad");
   });
 
   it("includes stack when stackTrace is true", async () => {

--- a/packages/error-handler/src/__test__/domainStatusMap.test.ts
+++ b/packages/error-handler/src/__test__/domainStatusMap.test.ts
@@ -1,0 +1,120 @@
+/* istanbul ignore file */
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ErrorHandlerOptions } from "../types";
+
+import errorHandlerPlugin, { CustomError } from "../index";
+import { FastifyInstance, makeLogSpy } from "./helpers";
+
+describe("errorHandlerPlugin — domainErrorStatusMap", () => {
+  let fastify: FastifyInstance;
+
+  afterEach(async () => await fastify.close());
+
+  it("responds with mapped status when error.name matches", async () => {
+    fastify = await buildFastify({
+      domainErrorStatusMap: { UnprocessableEntityError: 422 },
+    });
+    fastify.get("/test", async () => {
+      const err = new Error("validation failed");
+      err.name = "UnprocessableEntityError";
+      throw err;
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.statusCode).toBe(422);
+    expect(body.message).toBe("validation failed");
+    expect(body.name).toBe("UnprocessableEntityError");
+    expect(body.error).toBe("Unprocessable Entity");
+  });
+
+  it("includes CustomError.code on mapped responses", async () => {
+    class UnprocessableEntityError extends CustomError {
+      constructor(message: string) {
+        super(message, "UNPROCESSABLE_ENTITY");
+        this.name = "UnprocessableEntityError";
+      }
+    }
+
+    fastify = await buildFastify({
+      domainErrorStatusMap: { UnprocessableEntityError: 422 },
+    });
+    fastify.get("/test", async () => {
+      throw new UnprocessableEntityError("bad");
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe("UNPROCESSABLE_ENTITY");
+  });
+
+  it("includes stack when stackTrace is true", async () => {
+    fastify = await buildFastify({
+      domainErrorStatusMap: { MappedError: 409 },
+      stackTrace: true,
+    });
+    fastify.get("/test", async () => {
+      const err = new Error("conflict");
+      err.name = "MappedError";
+      throw err;
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/test" });
+    expect(res.json().stack).toBeDefined();
+  });
+});
+
+describe("errorHandlerPlugin — domainErrorStatusMap logging", () => {
+  let fastify: FastifyInstance;
+  let logSpy: ReturnType<typeof makeLogSpy>;
+
+  beforeEach(async () => {
+    logSpy = makeLogSpy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fastify = Fastify({ loggerInstance: logSpy as any });
+    await fastify.register(errorHandlerPlugin, {
+      domainErrorStatusMap: {
+        ClientErr: 422,
+        ServerMapped: 503,
+      },
+    });
+    fastify.get("/422", async () => {
+      const err = new Error("x");
+      err.name = "ClientErr";
+      throw err;
+    });
+    fastify.get("/503", async () => {
+      const err = new Error("y");
+      err.name = "ServerMapped";
+      throw err;
+    });
+    await fastify.ready();
+    vi.clearAllMocks();
+    logSpy.child.mockImplementation(() => logSpy);
+  });
+
+  afterEach(async () => await fastify.close());
+
+  it("logs mapped 4xx at info", async () => {
+    await fastify.inject({ method: "GET", url: "/422" });
+    expect(logSpy.info).toHaveBeenCalledWith(expect.any(Error));
+    expect(logSpy.error).not.toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("logs mapped 5xx at error", async () => {
+    await fastify.inject({ method: "GET", url: "/503" });
+    expect(logSpy.error).toHaveBeenCalledWith(expect.any(Error));
+    expect(logSpy.info).not.toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+async function buildFastify(
+  options: ErrorHandlerOptions,
+): Promise<FastifyInstance> {
+  const fastify = Fastify({ logger: false });
+  await fastify.register(errorHandlerPlugin, options);
+  return fastify;
+}

--- a/packages/error-handler/src/__test__/errorHandlerExport.test.ts
+++ b/packages/error-handler/src/__test__/errorHandlerExport.test.ts
@@ -15,7 +15,6 @@ describe("errorHandler — standalone export", () => {
   it("handles errors the same way as the plugin when wired with sensible and stackTrace", async () => {
     fastify = Fastify({ logger: false });
     fastify.decorate("stackTrace", false);
-    fastify.decorate("domainErrorStatusMap", new Map<string, number>());
     await fastify.register(fastifySensible);
     fastify.setErrorHandler((err, request, reply) => {
       errorHandler(err, request, reply);

--- a/packages/error-handler/src/__test__/errorHandlerExport.test.ts
+++ b/packages/error-handler/src/__test__/errorHandlerExport.test.ts
@@ -15,6 +15,7 @@ describe("errorHandler — standalone export", () => {
   it("handles errors the same way as the plugin when wired with sensible and stackTrace", async () => {
     fastify = Fastify({ logger: false });
     fastify.decorate("stackTrace", false);
+    fastify.decorate("domainErrorStatusMap", new Map<string, number>());
     await fastify.register(fastifySensible);
     fastify.setErrorHandler((err, request, reply) => {
       errorHandler(err, request, reply);

--- a/packages/error-handler/src/__test__/registration.test.ts
+++ b/packages/error-handler/src/__test__/registration.test.ts
@@ -38,7 +38,7 @@ describe("errorHandlerPlugin — registration", () => {
 
   it("decorates domainErrorStatusMap from registration option", async () => {
     const fastify = await buildFastify({
-      domainErrorStatusMap: { FooError: 418 },
+      domainErrorStatusMap: new Map([["FooError", 418]]),
     });
     await fastify.ready();
     expect(fastify.domainErrorStatusMap.get("FooError")).toBe(418);
@@ -49,7 +49,7 @@ describe("errorHandlerPlugin — registration", () => {
     const fastify = Fastify({ logger: false });
     await expect(
       fastify.register(errorHandlerPlugin, {
-        domainErrorStatusMap: { Bad: 99 },
+        domainErrorStatusMap: new Map([["Bad", 99]]),
       }),
     ).rejects.toThrow(/domainErrorStatusMap/);
     await fastify.close();
@@ -59,7 +59,7 @@ describe("errorHandlerPlugin — registration", () => {
     const fastify = Fastify({ logger: false });
     await expect(
       fastify.register(errorHandlerPlugin, {
-        domainErrorStatusMap: { Bad: 422.5 },
+        domainErrorStatusMap: new Map([["Bad", 422.5]]),
       }),
     ).rejects.toThrow(/domainErrorStatusMap/);
     await fastify.close();

--- a/packages/error-handler/src/__test__/registration.test.ts
+++ b/packages/error-handler/src/__test__/registration.test.ts
@@ -32,7 +32,7 @@ describe("errorHandlerPlugin — registration", () => {
     const fastify = await buildFastify();
     await fastify.ready();
     expect(fastify.domainErrorStatusMap).toBeInstanceOf(Map);
-    expect(fastify.domainErrorStatusMap?.size).toBe(0);
+    expect(fastify.domainErrorStatusMap.size).toBe(0);
     await fastify.close();
   });
 
@@ -41,7 +41,27 @@ describe("errorHandlerPlugin — registration", () => {
       domainErrorStatusMap: { FooError: 418 },
     });
     await fastify.ready();
-    expect(fastify.domainErrorStatusMap?.get("FooError")).toBe(418);
+    expect(fastify.domainErrorStatusMap.get("FooError")).toBe(418);
+    await fastify.close();
+  });
+
+  it("throws when domainErrorStatusMap has invalid HTTP status", async () => {
+    const fastify = Fastify({ logger: false });
+    await expect(
+      fastify.register(errorHandlerPlugin, {
+        domainErrorStatusMap: { Bad: 99 },
+      }),
+    ).rejects.toThrow(/domainErrorStatusMap/);
+    await fastify.close();
+  });
+
+  it("throws when domainErrorStatusMap status is not an integer", async () => {
+    const fastify = Fastify({ logger: false });
+    await expect(
+      fastify.register(errorHandlerPlugin, {
+        domainErrorStatusMap: { Bad: 422.5 },
+      }),
+    ).rejects.toThrow(/domainErrorStatusMap/);
     await fastify.close();
   });
 

--- a/packages/error-handler/src/__test__/registration.test.ts
+++ b/packages/error-handler/src/__test__/registration.test.ts
@@ -14,34 +14,19 @@ describe("errorHandlerPlugin — registration", () => {
     await fastify.close();
   });
 
-  it("decorates fastify with stackTrace: false by default", async () => {
-    const fastify = await buildFastify();
-    await fastify.ready();
-    expect(fastify.stackTrace).toBe(false);
-    await fastify.close();
-  });
-
-  it("decorates fastify with stackTrace: true when option is set", async () => {
+  it("accepts stackTrace option without decorating fastify", async () => {
     const fastify = await buildFastify({ stackTrace: true });
     await fastify.ready();
-    expect(fastify.stackTrace).toBe(true);
+    expect("stackTrace" in fastify).toBe(false);
     await fastify.close();
   });
 
-  it("decorates fastify with domainErrorStatusMap as empty Map when omitted", async () => {
-    const fastify = await buildFastify();
-    await fastify.ready();
-    expect(fastify.domainErrorStatusMap).toBeInstanceOf(Map);
-    expect(fastify.domainErrorStatusMap.size).toBe(0);
-    await fastify.close();
-  });
-
-  it("decorates domainErrorStatusMap from registration option", async () => {
+  it("accepts domainErrorStatusMap option without decorating fastify", async () => {
     const fastify = await buildFastify({
       domainErrorStatusMap: new Map([["FooError", 418]]),
     });
     await fastify.ready();
-    expect(fastify.domainErrorStatusMap.get("FooError")).toBe(418);
+    expect("domainErrorStatusMap" in fastify).toBe(false);
     await fastify.close();
   });
 

--- a/packages/error-handler/src/__test__/registration.test.ts
+++ b/packages/error-handler/src/__test__/registration.test.ts
@@ -28,6 +28,23 @@ describe("errorHandlerPlugin — registration", () => {
     await fastify.close();
   });
 
+  it("decorates fastify with domainErrorStatusMap as empty Map when omitted", async () => {
+    const fastify = await buildFastify();
+    await fastify.ready();
+    expect(fastify.domainErrorStatusMap).toBeInstanceOf(Map);
+    expect(fastify.domainErrorStatusMap?.size).toBe(0);
+    await fastify.close();
+  });
+
+  it("decorates domainErrorStatusMap from registration option", async () => {
+    const fastify = await buildFastify({
+      domainErrorStatusMap: { FooError: 418 },
+    });
+    await fastify.ready();
+    expect(fastify.domainErrorStatusMap?.get("FooError")).toBe(418);
+    await fastify.close();
+  });
+
   it("registers the ErrorResponse JSON schema", async () => {
     const fastify = await buildFastify();
     await fastify.ready();

--- a/packages/error-handler/src/errorHandler.ts
+++ b/packages/error-handler/src/errorHandler.ts
@@ -10,6 +10,45 @@ import { CustomError } from "./utils/error";
 const getHttpStatusText = (statusCode: number): string =>
   STATUS_CODES[statusCode] ?? "Internal Server Error";
 
+function trySendDomainMappedError(
+  error: Error,
+  request: FastifyRequest,
+  reply: FastifyReply,
+  logger: FastifyRequest["log"],
+  isStackTraceEnabled: boolean,
+  stack: StackTracey,
+): boolean {
+  const mappedStatusCode = request.server.domainErrorStatusMap?.get(error.name);
+
+  if (mappedStatusCode === undefined) {
+    return false;
+  }
+
+  if (mappedStatusCode >= 500) {
+    logger.error(error);
+  } else if (mappedStatusCode >= 400) {
+    logger.info(error);
+  } else {
+    logger.error(error);
+  }
+
+  const response: ErrorResponse = {
+    code: error instanceof CustomError ? error.code : undefined,
+    error: getHttpStatusText(mappedStatusCode),
+    message: error.message,
+    name: error.name,
+    statusCode: mappedStatusCode,
+  };
+
+  if (isStackTraceEnabled && error.stack) {
+    response.stack = stack.items;
+  }
+
+  void reply.code(mappedStatusCode).send(response);
+
+  return true;
+}
+
 export const errorHandler = (
   unknownError: unknown,
   request: FastifyRequest,
@@ -54,31 +93,16 @@ export const errorHandler = (
     return;
   }
 
-  const mappedStatusCode = request.server.domainErrorStatusMap?.get(error.name);
-
-  if (mappedStatusCode !== undefined) {
-    if (mappedStatusCode >= 500) {
-      logger.error(error);
-    } else if (mappedStatusCode >= 400) {
-      logger.info(error);
-    } else {
-      logger.error(error);
-    }
-
-    const response: ErrorResponse = {
-      code: error instanceof CustomError ? error.code : undefined,
-      error: getHttpStatusText(mappedStatusCode),
-      message: error.message,
-      name: error.name,
-      statusCode: mappedStatusCode,
-    };
-
-    if (isStackTraceEnabled && error.stack) {
-      response.stack = stack.items;
-    }
-
-    void reply.code(mappedStatusCode).send(response);
-
+  if (
+    trySendDomainMappedError(
+      error,
+      request,
+      reply,
+      logger,
+      isStackTraceEnabled,
+      stack,
+    )
+  ) {
     return;
   }
 

--- a/packages/error-handler/src/errorHandler.ts
+++ b/packages/error-handler/src/errorHandler.ts
@@ -54,6 +54,34 @@ export const errorHandler = (
     return;
   }
 
+  const mappedStatusCode = request.server.domainErrorStatusMap?.get(error.name);
+
+  if (mappedStatusCode !== undefined) {
+    if (mappedStatusCode >= 500) {
+      logger.error(error);
+    } else if (mappedStatusCode >= 400) {
+      logger.info(error);
+    } else {
+      logger.error(error);
+    }
+
+    const response: ErrorResponse = {
+      code: error instanceof CustomError ? error.code : undefined,
+      error: getHttpStatusText(mappedStatusCode),
+      message: error.message,
+      name: error.name,
+      statusCode: mappedStatusCode,
+    };
+
+    if (isStackTraceEnabled && error.stack) {
+      response.stack = stack.items;
+    }
+
+    void reply.code(mappedStatusCode).send(response);
+
+    return;
+  }
+
   let code = "INTERNAL_SERVER_ERROR";
   let message = "Server error, please contact support";
 

--- a/packages/error-handler/src/errorHandler.ts
+++ b/packages/error-handler/src/errorHandler.ts
@@ -54,7 +54,7 @@ export const errorHandler = (
     return;
   }
 
-  const mappedStatusCode = request.server.domainErrorStatusMap.get(error.name);
+  const mappedStatusCode = request.server.domainErrorStatusMap?.get(error.name);
 
   if (mappedStatusCode !== undefined) {
     if (mappedStatusCode >= 500) {
@@ -65,20 +65,11 @@ export const errorHandler = (
       logger.error(error);
     }
 
-    let responseCode = "INTERNAL_SERVER_ERROR";
-    let maskedMessage = "Server error, please contact support";
-
-    if (error instanceof CustomError) {
-      responseCode = error.code || responseCode;
-      maskedMessage =
-        "Server has an error that is not handled, please contact support";
-    }
-
     const response: ErrorResponse = {
-      code: isStackTraceEnabled ? responseCode : "INTERNAL_SERVER_ERROR",
+      code: error instanceof CustomError ? error.code : undefined,
       error: getHttpStatusText(mappedStatusCode),
-      message: isStackTraceEnabled ? error.message : maskedMessage,
-      name: isStackTraceEnabled ? error.name : "Error",
+      message: error.message,
+      name: error.name,
       statusCode: mappedStatusCode,
     };
 

--- a/packages/error-handler/src/errorHandler.ts
+++ b/packages/error-handler/src/errorHandler.ts
@@ -54,7 +54,7 @@ export const errorHandler = (
     return;
   }
 
-  const mappedStatusCode = request.server.domainErrorStatusMap?.get(error.name);
+  const mappedStatusCode = request.server.domainErrorStatusMap.get(error.name);
 
   if (mappedStatusCode !== undefined) {
     if (mappedStatusCode >= 500) {
@@ -65,11 +65,20 @@ export const errorHandler = (
       logger.error(error);
     }
 
+    let responseCode = "INTERNAL_SERVER_ERROR";
+    let maskedMessage = "Server error, please contact support";
+
+    if (error instanceof CustomError) {
+      responseCode = error.code || responseCode;
+      maskedMessage =
+        "Server has an error that is not handled, please contact support";
+    }
+
     const response: ErrorResponse = {
-      code: error instanceof CustomError ? error.code : undefined,
+      code: isStackTraceEnabled ? responseCode : "INTERNAL_SERVER_ERROR",
       error: getHttpStatusText(mappedStatusCode),
-      message: error.message,
-      name: error.name,
+      message: isStackTraceEnabled ? error.message : maskedMessage,
+      name: isStackTraceEnabled ? error.name : "Error",
       statusCode: mappedStatusCode,
     };
 

--- a/packages/error-handler/src/errorHandler.ts
+++ b/packages/error-handler/src/errorHandler.ts
@@ -3,7 +3,7 @@ import { FastifyReply, FastifyRequest } from "fastify";
 import { STATUS_CODES } from "node:http";
 import StackTracey from "stacktracey";
 
-import type { ErrorResponse } from "./types";
+import type { ErrorHandlerOptions, ErrorResponse } from "./types";
 
 import { CustomError } from "./utils/error";
 
@@ -12,13 +12,13 @@ const getHttpStatusText = (statusCode: number): string =>
 
 function trySendDomainMappedError(
   error: Error,
-  request: FastifyRequest,
+  domainErrorStatusMap: ReadonlyMap<string, number> | undefined,
   reply: FastifyReply,
   logger: FastifyRequest["log"],
   isStackTraceEnabled: boolean,
   stack: StackTracey,
 ): boolean {
-  const mappedStatusCode = request.server.domainErrorStatusMap?.get(error.name);
+  const mappedStatusCode = domainErrorStatusMap?.get(error.name);
 
   if (mappedStatusCode === undefined) {
     return false;
@@ -53,13 +53,14 @@ export const errorHandler = (
   unknownError: unknown,
   request: FastifyRequest,
   reply: FastifyReply,
+  options: ErrorHandlerOptions = {},
 ) => {
   const error =
     unknownError instanceof Error ? unknownError : new Error("UNKNOWN_ERROR");
 
   const { log: logger } = request;
 
-  const isStackTraceEnabled = request.server.stackTrace || false;
+  const isStackTraceEnabled = options.stackTrace || false;
 
   const stack = new StackTracey(error);
 
@@ -96,7 +97,7 @@ export const errorHandler = (
   if (
     trySendDomainMappedError(
       error,
-      request,
+      options.domainErrorStatusMap,
       reply,
       logger,
       isStackTraceEnabled,

--- a/packages/error-handler/src/index.ts
+++ b/packages/error-handler/src/index.ts
@@ -2,9 +2,7 @@ import type { HttpErrors } from "@fastify/sensible";
 
 declare module "fastify" {
   interface FastifyInstance {
-    domainErrorStatusMap?: Map<string, number>;
     httpErrors: HttpErrors;
-    stackTrace: boolean;
   }
 }
 

--- a/packages/error-handler/src/index.ts
+++ b/packages/error-handler/src/index.ts
@@ -2,6 +2,7 @@ import type { HttpErrors } from "@fastify/sensible";
 
 declare module "fastify" {
   interface FastifyInstance {
+    domainErrorStatusMap?: Map<string, number>;
     httpErrors: HttpErrors;
     stackTrace: boolean;
   }

--- a/packages/error-handler/src/index.ts
+++ b/packages/error-handler/src/index.ts
@@ -2,7 +2,7 @@ import type { HttpErrors } from "@fastify/sensible";
 
 declare module "fastify" {
   interface FastifyInstance {
-    domainErrorStatusMap?: Map<string, number>;
+    domainErrorStatusMap: Map<string, number>;
     httpErrors: HttpErrors;
     stackTrace: boolean;
   }

--- a/packages/error-handler/src/index.ts
+++ b/packages/error-handler/src/index.ts
@@ -2,7 +2,7 @@ import type { HttpErrors } from "@fastify/sensible";
 
 declare module "fastify" {
   interface FastifyInstance {
-    domainErrorStatusMap: Map<string, number>;
+    domainErrorStatusMap?: Map<string, number>;
     httpErrors: HttpErrors;
     stackTrace: boolean;
   }

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -8,6 +8,29 @@ import type { ErrorHandlerOptions } from "./types";
 import { errorHandler } from "./errorHandler";
 import { errorSchema } from "./utils/errorSchema";
 
+const DOMAIN_STATUS_MIN = 100;
+const DOMAIN_STATUS_MAX = 599;
+
+function assertDomainErrorStatusMap(
+  map: Readonly<Record<string, number>> | undefined,
+): void {
+  if (map === undefined) {
+    return;
+  }
+  for (const [errorName, statusCode] of Object.entries(map)) {
+    if (
+      typeof statusCode !== "number" ||
+      !Number.isInteger(statusCode) ||
+      statusCode < DOMAIN_STATUS_MIN ||
+      statusCode > DOMAIN_STATUS_MAX
+    ) {
+      throw new Error(
+        `domainErrorStatusMap: invalid HTTP status for "${errorName}": ${String(statusCode)} (expected integer ${DOMAIN_STATUS_MIN}-${DOMAIN_STATUS_MAX})`,
+      );
+    }
+  }
+}
+
 const plugin = async (
   fastify: FastifyInstance,
   options: ErrorHandlerOptions,
@@ -15,6 +38,8 @@ const plugin = async (
   fastify.log.info("Registering fastify-error-handler plugin");
 
   fastify.decorate("stackTrace", options.stackTrace || false);
+
+  assertDomainErrorStatusMap(options.domainErrorStatusMap);
 
   const domainErrorStatusMap = new Map<string, number>(
     Object.entries(options.domainErrorStatusMap ?? {}),

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -31,6 +31,7 @@ function buildDomainErrorStatusMap(
         `domainErrorStatusMap: invalid HTTP status for "${errorName}": ${String(statusCode)} (expected integer ${DOMAIN_STATUS_MIN}-${DOMAIN_STATUS_MAX})`,
       );
     }
+
     result.set(errorName, statusCode);
   }
 

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -11,11 +11,12 @@ import { errorSchema } from "./utils/errorSchema";
 const DOMAIN_STATUS_MIN = 100;
 const DOMAIN_STATUS_MAX = 599;
 
-function assertDomainErrorStatusMap(
+function buildDomainErrorStatusMap(
   map: Readonly<Record<string, number>> | undefined,
-): void {
+): Map<string, number> {
+  const result = new Map<string, number>();
   if (map === undefined) {
-    return;
+    return result;
   }
   for (const [errorName, statusCode] of Object.entries(map)) {
     if (
@@ -28,7 +29,9 @@ function assertDomainErrorStatusMap(
         `domainErrorStatusMap: invalid HTTP status for "${errorName}": ${String(statusCode)} (expected integer ${DOMAIN_STATUS_MIN}-${DOMAIN_STATUS_MAX})`,
       );
     }
+    result.set(errorName, statusCode);
   }
+  return result;
 }
 
 const plugin = async (
@@ -39,10 +42,8 @@ const plugin = async (
 
   fastify.decorate("stackTrace", options.stackTrace || false);
 
-  assertDomainErrorStatusMap(options.domainErrorStatusMap);
-
-  const domainErrorStatusMap = new Map<string, number>(
-    Object.entries(options.domainErrorStatusMap ?? {}),
+  const domainErrorStatusMap = buildDomainErrorStatusMap(
+    options.domainErrorStatusMap,
   );
 
   fastify.decorate("domainErrorStatusMap", domainErrorStatusMap);

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -12,7 +12,7 @@ const DOMAIN_STATUS_MIN = 400;
 const DOMAIN_STATUS_MAX = 599;
 
 function buildDomainErrorStatusMap(
-  map: Readonly<Record<string, number>> | undefined,
+  map: ReadonlyMap<string, number> | undefined,
 ): Map<string, number> {
   const result = new Map<string, number>();
 
@@ -20,7 +20,7 @@ function buildDomainErrorStatusMap(
     return result;
   }
 
-  for (const [errorName, statusCode] of Object.entries(map)) {
+  for (const [errorName, statusCode] of map.entries()) {
     if (
       typeof statusCode !== "number" ||
       !Number.isInteger(statusCode) ||

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -8,16 +8,18 @@ import type { ErrorHandlerOptions } from "./types";
 import { errorHandler } from "./errorHandler";
 import { errorSchema } from "./utils/errorSchema";
 
-const DOMAIN_STATUS_MIN = 100;
+const DOMAIN_STATUS_MIN = 400;
 const DOMAIN_STATUS_MAX = 599;
 
 function buildDomainErrorStatusMap(
   map: Readonly<Record<string, number>> | undefined,
 ): Map<string, number> {
   const result = new Map<string, number>();
+
   if (map === undefined) {
     return result;
   }
+
   for (const [errorName, statusCode] of Object.entries(map)) {
     if (
       typeof statusCode !== "number" ||
@@ -31,6 +33,7 @@ function buildDomainErrorStatusMap(
     }
     result.set(errorName, statusCode);
   }
+
   return result;
 }
 

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -16,6 +16,12 @@ const plugin = async (
 
   fastify.decorate("stackTrace", options.stackTrace || false);
 
+  const domainErrorStatusMap = new Map<string, number>(
+    Object.entries(options.domainErrorStatusMap ?? {}),
+  );
+
+  fastify.decorate("domainErrorStatusMap", domainErrorStatusMap);
+
   await fastify.register(fastifySensible);
 
   fastify.setErrorHandler(async (error, request, reply) => {

--- a/packages/error-handler/src/plugin.ts
+++ b/packages/error-handler/src/plugin.ts
@@ -43,14 +43,10 @@ const plugin = async (
   options: ErrorHandlerOptions,
 ) => {
   fastify.log.info("Registering fastify-error-handler plugin");
-
-  fastify.decorate("stackTrace", options.stackTrace || false);
-
-  const domainErrorStatusMap = buildDomainErrorStatusMap(
+  options.stackTrace = options.stackTrace || false;
+  options.domainErrorStatusMap = buildDomainErrorStatusMap(
     options.domainErrorStatusMap,
   );
-
-  fastify.decorate("domainErrorStatusMap", domainErrorStatusMap);
 
   await fastify.register(fastifySensible);
 
@@ -67,7 +63,7 @@ const plugin = async (
       }
     }
 
-    return errorHandler(error, request, reply);
+    return errorHandler(error, request, reply, options);
   });
 
   fastify.addSchema(errorSchema);

--- a/packages/error-handler/src/types.ts
+++ b/packages/error-handler/src/types.ts
@@ -8,6 +8,8 @@ type ErrorHandler = (
 ) => Promise<void> | void;
 
 interface ErrorHandlerOptions {
+  /** Maps `error.name` (domain error class names or constants) to HTTP status codes (e.g. 422). */
+  domainErrorStatusMap?: Readonly<Record<string, number>>;
   preErrorHandler?: ErrorHandler;
   stackTrace?: boolean;
 }

--- a/packages/error-handler/src/types.ts
+++ b/packages/error-handler/src/types.ts
@@ -8,7 +8,6 @@ type ErrorHandler = (
 ) => Promise<void> | void;
 
 interface ErrorHandlerOptions {
-  /** Maps `error.name` (domain error class names or constants) to HTTP status codes (integers `100`–`599`; invalid values throw at registration). */
   domainErrorStatusMap?: Readonly<Record<string, number>>;
   preErrorHandler?: ErrorHandler;
   stackTrace?: boolean;

--- a/packages/error-handler/src/types.ts
+++ b/packages/error-handler/src/types.ts
@@ -8,7 +8,7 @@ type ErrorHandler = (
 ) => Promise<void> | void;
 
 interface ErrorHandlerOptions {
-  domainErrorStatusMap?: Readonly<Record<string, number>>;
+  domainErrorStatusMap?: ReadonlyMap<string, number>;
   preErrorHandler?: ErrorHandler;
   stackTrace?: boolean;
 }

--- a/packages/error-handler/src/types.ts
+++ b/packages/error-handler/src/types.ts
@@ -8,7 +8,7 @@ type ErrorHandler = (
 ) => Promise<void> | void;
 
 interface ErrorHandlerOptions {
-  /** Maps `error.name` (domain error class names or constants) to HTTP status codes (e.g. 422). */
+  /** Maps `error.name` (domain error class names or constants) to HTTP status codes (integers `100`–`599`; invalid values throw at registration). */
   domainErrorStatusMap?: Readonly<Record<string, number>>;
   preErrorHandler?: ErrorHandler;
   stackTrace?: boolean;


### PR DESCRIPTION
## Summary

Refactors error-handler configuration flow so plugin options are passed directly to the runtime error handler instead of decorating the Fastify instance.

## What changed

- Stop decorating `fastify.stackTrace` and `fastify.domainErrorStatusMap` in the plugin.
- Normalize and keep `stackTrace` and `domainErrorStatusMap` in plugin options, then pass those options into `errorHandler(...)`.
- Update `errorHandler` to read config from `ErrorHandlerOptions` (including domain status lookup) rather than `request.server` decorations.
- Remove now-unused Fastify instance type augmentation entries from `index.ts`.
- Update registration tests to assert options are accepted without adding instance decorations.

## Why

This keeps plugin configuration scoped to plugin behavior, avoids expanding Fastify instance surface area, and makes the standalone handler path more explicit and predictable.

## Validation

- Commit hooks ran successfully (lint, typecheck, tests).