### PR TITLE
ci: split pnpm setup and install in shipjs-trigger workflow

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -14,18 +14,16 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
       - name: Setup node 24
         uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
-      - name: Setup pnpm and install dependencies
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: |
-            - recursive: true
-              args: [--frozen-lockfile, --strict-peer-dependencies]
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --strict-peer-dependencies
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## ci: split pnpm setup and install in shipjs-trigger workflow

Updates `.github/workflows/shipjs-trigger.yml` so pnpm is set up before `actions/setup-node` runs (so `cache: "pnpm"` can locate pnpm), and dependency installation is moved into a dedicated step using `pnpm install --frozen-lockfile --strict-peer-dependencies`.

### Tasks completed
- Add a dedicated `Setup pnpm` step using `pnpm/action-setup@v4` ahead of `actions/setup-node` so the `cache: "pnpm"` option resolves correctly.
- Replace the combined pnpm setup + `run_install` block with a separate `Install dependencies` step running `pnpm install --frozen-lockfile --strict-peer-dependencies`.
- Restore the trailing newline at the end of the workflow file to match the sibling workflows' style.