### PR TITLE
feat(s3): accept plugin options directly, deprecate fastify.config fa…

### DIFF
--- a/docs/specs/graphql-upload-transport.md
+++ b/docs/specs/graphql-upload-transport.md
@@ -1,0 +1,244 @@
+# Spec: Move GraphQL upload transport from `fastify-s3` to `fastify-graphql`
+
+Status: draft, pending decisions in §8. Companion to the plugin-options migration
+(step 1 already implemented in `packages/s3`, uncommitted).
+
+## 1. Problem statement
+
+GraphQL file upload currently requires three coordinated pieces across two
+packages plus the consuming app: `multipartParserPlugin` (s3 export,
+app-registered, must precede the graphql plugin), the `graphqlUpload`
+preValidation hook (s3-internal, registered when s3's graphql mode is on), and
+mercurius (graphql package). This creates:
+
+- a **hidden dependency**: `user`'s GraphQL `uploadPhoto` silently requires an
+  app-level parser registration that no package declares or documents;
+- an **ordering footgun**: parser-after-mercurius fails at request time with an
+  unexplained 415/422 (verified experimentally — content-type parsers are
+  snapshotted at encapsulation-context creation; hooks are bound at ready time);
+- **misplaced ownership**: multipart-transport concerns live in a storage
+  package.
+
+## 2. Target design
+
+### 2.1 New public API (graphql package)
+
+```typescript
+// packages/graphql/src/types.ts
+import type { UploadOptions } from "graphql-upload-minimal";
+
+export interface GraphqlUploadsConfig extends UploadOptions {
+  enabled?: boolean; // default: true — house convention, disable check is === false (see 2.4)
+}
+
+export interface GraphqlConfig extends MercuriusOptions {
+  enabled?: boolean;
+  plugins?: GraphqlEnabledPlugin[];
+  uploads?: GraphqlUploadsConfig; // NEW
+}
+```
+
+`UploadOptions` passthrough gives `maxFileSize`, `maxFiles`, `maxFieldSize`
+(classified PARTIAL passthrough in GUIDE.md). Consumer usage:
+
+```typescript
+await fastify.register(graphqlPlugin, {
+  ...config.graphql,
+  uploads: { enabled: true, maxFileSize: 10_485_760 },
+});
+```
+
+### 2.2 New internal module: `packages/graphql/src/uploads/`
+
+- `transport.ts` — one fastify-plugin-wrapped sub-plugin, **named**
+  (`name: "prefabs-graphql-upload-transport"`), containing both halves of
+  today's split:
+  1. the catch-all `*` content-type parser: multipart request to the graphql
+     path → set `req.graphqlFileUploadMultipart = true`, leave the stream
+     untouched; multipart elsewhere → busboy parse into `req.body` (today's
+     `processMultipartFormData`, which moves here — it has exactly one caller);
+     non-multipart → fall through.
+  2. the `preValidation` hook: if flagged,
+     `request.body = await processRequest(request.raw, reply.raw, uploadOptions)`.
+- The graphql path is resolved **inside the plugin** as
+  `options.path ?? DEFAULT_GRAPHQL_PATH` ("/graphql"; constant moves from s3 to
+  graphql constants) — no config lookup, no cross-package agreement needed; the
+  package that owns the endpoint owns the path.
+
+### 2.3 Registration flow (`packages/graphql/src/plugin.ts`)
+
+```typescript
+if (options?.enabled) {
+  if (
+    options.uploads?.enabled !== false &&
+    !fastify.hasPlugin("prefabs-graphql-upload-transport")
+  ) {
+    await fastify.register(uploadTransport, {
+      path: options.path,
+      ...options.uploads,
+    });
+  }
+  await fastify.register(mercurius, {
+    context: buildContext(options.plugins),
+    ...options,
+  });
+}
+```
+
+**Ordering is now correct by construction**: the parser is added in the same
+(fastify-plugin, root) context *before* mercurius's context is created. The
+`hasPlugin` guard makes the transitional case safe: an app still registering
+the legacy s3 `multipartParserPlugin` (same underlying named plugin, see 3.2)
+*and* enabling `uploads` won't hit `FST_ERR_CTP_ALREADY_PRESENT` from a double
+`*` parser.
+
+### 2.4 Defaults and constraints
+
+- `uploads.enabled` defaults **on** (decided §8.3): the disable check is
+  `uploads?.enabled === false`, per house convention. Consequences, accepted
+  and documented rather than mitigated: every graphql-enabled app gets the
+  catch-all `*` parser on upgrade — (a) an app that registered its **own** `*`
+  parser will now throw `FST_ERR_CTP_ALREADY_PRESENT` at startup and must set
+  `uploads: { enabled: false }`; (b) unknown-content-type requests that
+  previously got 415 now reach routes with an undefined body, and stray
+  multipart requests to non-graphql routes are busboy-parsed. Both called out
+  in the graphql GUIDE and the release notes.
+- If the app already has its own (non-prefabs) `*` parser, registration throws
+  Fastify's `FST_ERR_CTP_ALREADY_PRESENT`. Not pre-checkable
+  (`hasContentTypeParser("*")` false-negative gotcha, CLAUDE.md gotcha #1) —
+  documented, not swallowed.
+- The `scalar Upload` SDL declaration stays consumer-side (as `user`'s
+  `schema.ts:4` does today); mercurius passes upload promises through without a
+  scalar resolver — unchanged.
+- Module augmentation `FastifyRequest.graphqlFileUploadMultipart` moves to
+  **graphql's `index.ts`** (also fixes the existing house-rule violation of
+  declaring it in two s3 plugin files).
+- **Mixed mode (REST + GraphQL uploads) retains one ordering rule that this
+  move does not fix**: the s3 plugin must still be registered *after* the
+  graphql plugin. `@fastify/multipart` (s3 `rest.enabled`) registers a
+  dedicated `multipart/form-data` parser, and a dedicated parser beats the
+  catch-all. If s3 ran first, mercurius's context would snapshot that dedicated
+  parser and `@fastify/multipart` would consume GraphQL upload bodies before
+  `processRequest` saw them. Registered after (as all current examples already
+  do), mercurius's context predates it and only sees the catch-all. Same as the
+  status quo — but now documented (graphql GUIDE + s3 GUIDE).
+
+## 3. Package-by-package changes
+
+### 3.1 `packages/graphql`
+
+| Change | Detail |
+|---|---|
+| New files | `src/uploads/transport.ts`, `src/uploads/processMultipartFormData.ts` (moved from s3 utils) |
+| `types.ts` | add `GraphqlUploadsConfig`, extend `GraphqlConfig` |
+| `plugin.ts` | register transport before mercurius (2.3) |
+| `constants.ts` | new file: `DEFAULT_GRAPHQL_PATH` |
+| `index.ts` | export the transport (name per §8.2), `GraphqlUploadsConfig`; re-export `FileUpload as GraphQLFileUpload`, `Upload as GraphQLUpload` types; add the request augmentation |
+| `package.json` | **new runtime deps**: `busboy` + `graphql-upload-minimal` (+ `@types/busboy` dev). Requires explicit approval per repo rules (§8.1). |
+
+### 3.2 `packages/s3` (all backward-compatible until the major)
+
+| Change | Detail |
+|---|---|
+| Delete | `src/plugins/graphqlUpload.ts`, `src/plugins/multipartParser.ts`, `processMultipartFormData` from utils (`convertStreamToBuffer` stays — s3Client uses it) |
+| `plugin.ts` | drop the `options.graphql?.enabled` branch entirely; drop `graphql` from the config-fallback composition |
+| `types/index.ts` | `S3Options` loses `graphql`; `S3GraphqlConfig` and `MultipartParserOptions` deleted; `fileSizeLimitInBytes` now REST-only (the GraphQL upload limit lives in `uploads.maxFileSize`) |
+| `constants.ts` | remove `DEFAULT_GRAPHQL_PATH` |
+| `index.ts` | deprecated compat re-exports, removed at the major: `multipartParserPlugin` (a thin named wrapper that registers graphql's transport only if `hasPlugin` doesn't already see it — making BOTH registration orders safe, since with uploads defaulting on the graphql plugin usually registers the transport first; the wrapper logs a deprecation warning), `GraphQLUpload`/`GraphQLFileUpload` types (re-exported from the graphql pkg) |
+| `package.json` | drop `busboy`, `@types/busboy`, `graphql-upload-minimal` from `dependencies` (no longer referenced; type re-exports come via the existing `@prefabs.tech/fastify-graphql` peer) |
+
+Because the aliased legacy `multipartParserPlugin` is the *full* transport
+(parser + hook), legacy apps that register it keep working uploads during the
+window even without `uploads.enabled` — step 1 stays truly non-breaking.
+
+### 3.3 `packages/user`
+
+| Change | Detail |
+|---|---|
+| `model/users/graphql/resolver.ts:4` | import `GraphQLUpload` from `@prefabs.tech/fastify-graphql` (already a peer); `Multipart` stays from s3 |
+| Docs | README example: drop `multipartParserPlugin` registration, show `uploads: { enabled: true }` on the graphql plugin; GUIDE.md + FEATURES.md: **conditional** prerequisite note on the photo features |
+
+The user plugin itself does **not** require graphql: REST-only deployments are
+fully supported (`user/src/plugin.ts:30` guards all graphql wiring behind
+`if (graphql?.enabled)`, and a REST `uploadPhoto` handler exists). The
+prerequisite wording is therefore conditional: *"the GraphQL `uploadPhoto`
+mutation requires `uploads.enabled` on the graphql plugin; the REST photo route
+requires multipart parsing (s3 `rest.enabled`)."* The former hidden dependency
+becomes one documented flag on a plugin the deployment already uses.
+
+## 4. Compatibility window
+
+Same two-step scheme as the plugin-options migration:
+
+- **Step 1 (this change, non-breaking):** new `uploads` option on the graphql
+  plugin; legacy path (app registers s3's `multipartParserPlugin` alias) keeps
+  working, including upload processing. Deprecation is signaled in s3's docs
+  and by the s3 plugin's config-fallback warning when it finds
+  `fastify.config.graphql?.enabled`.
+- **Step 2 (next major):** remove s3's compat re-exports and any `S3Options`
+  leftovers; `uploads` becomes the only path.
+
+## 5. Docs changes
+
+- **graphql package** (README, GUIDE, FEATURES): new "GraphQL file uploads"
+  section — the `uploads` option, `UploadOptions` PARTIAL passthrough
+  classification, default-off rationale, the `*`-parser global-slot caveat
+  (`FST_ERR_CTP_ALREADY_PRESENT` if the app has its own catch-all), the
+  mixed-mode ordering rule (s3 after graphql, §2.4), and the consumer-side
+  `scalar Upload` SDL requirement.
+- **s3 package** (README, GUIDE, FEATURES): remove the GraphQL upload sections;
+  point to the graphql package's uploads docs; extend the existing
+  "Deprecated: configuration via `fastify.config`" README section to also cover
+  the deprecated `multipartParserPlugin` / `GraphQLUpload` re-exports.
+- **s3 flags clarification** (README Configuration section + GUIDE feature 1):
+  state explicitly what the flags gate and that **both may be off**:
+  `rest.enabled` and GraphQL uploads only control *incoming HTTP upload
+  parsing*. With both off the plugin still runs migrations and provides a fully
+  functional `FileService`/`S3Client` — legitimate configurations include
+  presigned-URL flows (client uploads directly to S3), server-generated files
+  (reports, exports, thumbnails), and download-only services. "Both flags off"
+  means "this API doesn't accept file bytes over HTTP", not "the plugin is
+  inert". No validation or warning is added for this configuration.
+- **user package** (README, GUIDE, FEATURES): registration example updated
+  (drop `multipartParserPlugin`, show `uploads: { enabled: true }`); the
+  conditional photo-feature prerequisite note from §3.3.
+
+## 6. Tests
+
+Each new branch, real Fastify instances, no base-library mocks.
+
+- **graphql:** uploads disabled → no `*` parser (unknown content type still
+  415s); enabled → multipart to the graphql path is flagged and `processRequest`
+  populates the body (real `graphql-upload-minimal`, modeled on s3's existing
+  `graphqlUpload.test.ts`); custom `path` honored; default path when unset;
+  non-graphql multipart busboy-parsed; `hasPlugin` dedupe (legacy alias
+  registered first → no throw); `maxFileSize` passthrough.
+- **s3:** delete moved-code tests; one wiring test that the deprecated
+  re-exports exist and register cleanly; `S3Options` tests drop graphql cases.
+- **user:** none beyond the import-source change (resolver tests unaffected).
+
+## 7. Sequencing
+
+1. **Commit the current uncommitted s3 step-1 work first** (it was lost to a
+   hard reset once already): `feat(s3): accept plugin options directly,
+   deprecate fastify.config fallback`.
+2. Implement this spec on the same branch as follow-up commits, **before the
+   release train ships**, so `S3Options.graphql` never reaches npm only to be
+   deprecated a release later:
+   - `feat(graphql): own the GraphQL upload transport`
+   - `refactor(s3): delegate upload transport to fastify-graphql`
+   - `docs(user): document graphql-uploads prerequisite`
+3. Full root gate (`pnpm lint && pnpm typecheck && pnpm build && pnpm test`)
+   between commits; GUIDE/FEATURES updated in the same commit as the behavior
+   they describe.
+
+## 8. Decisions (resolved 2026-07-11)
+
+1. New runtime deps on the graphql package (`busboy`, `graphql-upload-minimal`)
+   — **approved**.
+2. New export name — **`graphqlUploadTransport`**; `multipartParserPlugin`
+   survives only as s3's deprecated alias.
+3. `uploads.enabled` — **default ON** (house convention; disable check is
+   `=== false`; consequences documented in §2.4).
+4. Sequencing — **fold into the current release train** per §7; s3 step-1 work
+   committed first as a checkpoint.

--- a/packages/graphql/FEATURES.md
+++ b/packages/graphql/FEATURES.md
@@ -49,3 +49,9 @@
 14. **`gql`** tag re-exported from `graphql-tag` — parses GraphQL template literals into `DocumentNode`.
 
 15. **`DocumentNode`** type re-exported from `graphql`.
+
+16. **GraphQL upload transport (`uploads` option)** — When the plugin is enabled, a named sub-plugin (`prefabs-graphql-upload-transport`) is registered before mercurius unless `uploads.enabled === false` (default on) or a transport with the same name is already present (`hasPlugin` check). It adds (a) a catch-all `"*"` content-type parser that flags multipart requests to the GraphQL path (`options.path`, default `"/graphql"`) via `request.graphqlFileUploadMultipart = true` and busboy-parses multipart requests to other routes into `req.body` (`{ ...fields, ...files }`, files as `MultipartFile[]`), and (b) a `preValidation` hook that runs `processRequest` from `graphql-upload-minimal` on flagged requests. `uploads` extends `UploadOptions` (`maxFileSize`, `maxFiles`, ...). Augments `FastifyRequest` with `graphqlFileUploadMultipart?: boolean`.
+
+17. **`graphqlUploadTransport` export** — The upload transport as a standalone plugin for apps that need to register it manually (custom ordering); options: `{ path?: string } & GraphqlUploadsConfig`.
+
+18. **Upload type exports** — `GraphqlUploadsConfig`, `MultipartFile`, and the `GraphQLUpload` / `GraphQLFileUpload` types re-exported from `graphql-upload-minimal`. Constants `DEFAULT_GRAPHQL_PATH` and `UPLOAD_TRANSPORT_PLUGIN_NAME` are also exported.

--- a/packages/graphql/GUIDE.md
+++ b/packages/graphql/GUIDE.md
@@ -113,6 +113,18 @@ Docs: https://graphql.org/graphql-js/ / https://www.npmjs.com/package/graphql
 
 Only the `DocumentNode` type is re-exported. No runtime code from this library is executed by us.
 
+### graphql-upload-minimal — Partial Passthrough
+
+Docs: https://www.npmjs.com/package/graphql-upload-minimal
+
+Used by the upload transport (Feature 16). `processRequest` is called internally for flagged multipart GraphQL requests; its `UploadOptions` (`maxFileSize`, `maxFiles`, `maxFieldSize`, ...) are exposed through the `uploads` option. The `Upload` and `FileUpload` types are re-exported as `GraphQLUpload` and `GraphQLFileUpload`.
+
+### busboy — Full Passthrough (internal)
+
+Docs: https://www.npmjs.com/package/busboy
+
+Used internally by the upload transport to parse multipart requests outside the GraphQL path. Not exposed to consumers.
+
 ---
 
 ## Features
@@ -405,6 +417,34 @@ function buildSchema(extra: DocumentNode[]): DocumentNode {
   return mergeTypeDefs([baseSchema, ...extra]);
 }
 ```
+
+### 16. GraphQL file uploads (`uploads` option + `graphqlUploadTransport`)
+
+When the plugin is enabled it also registers the upload transport — a named sub-plugin (`prefabs-graphql-upload-transport`) that makes GraphQL file uploads (via the [graphql multipart request spec](https://github.com/jaydenseric/graphql-multipart-request-spec)) work end to end:
+
+1. A catch-all `*` content-type parser: multipart requests to the GraphQL path (`options.path`, default `/graphql`) are flagged (`request.graphqlFileUploadMultipart = true`) and their stream left untouched; multipart requests to any other route are parsed with busboy into `req.body` (`{ ...fields, ...files }`, file values are `MultipartFile[]` arrays); other unknown content types fall through unchanged.
+2. A `preValidation` hook that runs `processRequest` from `graphql-upload-minimal` on flagged requests, so resolvers receive `Upload` values.
+
+```typescript
+await fastify.register(graphqlPlugin, {
+  ...config.graphql,
+  uploads: { maxFileSize: 10_485_760 }, // UploadOptions passthrough
+});
+```
+
+The transport is **enabled by default** (disable check is `uploads.enabled === false`). Declare `scalar Upload` in your SDL; resolvers receive the upload as a promise (`const upload = await args.file; upload.createReadStream()`).
+
+```typescript
+// Disable uploads entirely:
+await fastify.register(graphqlPlugin, { ...config.graphql, uploads: { enabled: false } });
+```
+
+Gotchas:
+
+- The `*` parser is a single app-global slot. If your app registers its own catch-all parser, registration throws Fastify's `FST_ERR_CTP_ALREADY_PRESENT` — set `uploads: { enabled: false }` and manage multipart parsing yourself. (`hasContentTypeParser("*")` cannot detect this ahead of time; see the repo's known Fastify gotchas.)
+- With the transport active, unknown content types no longer return 415 — the request reaches the route with an undefined body.
+- Mixed REST + GraphQL uploads with `@prefabs.tech/fastify-s3`: register the s3 plugin **after** this plugin. `@fastify/multipart` (s3 REST mode) adds a dedicated `multipart/form-data` parser; registered after mercurius it cannot leak into the GraphQL route's context, registered before it would consume GraphQL upload bodies.
+- If the transport is already registered (e.g. via the deprecated `multipartParserPlugin` re-export from `@prefabs.tech/fastify-s3`), the plugin detects it with `hasPlugin` and skips its own registration.
 
 ---
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -142,6 +142,19 @@ The `graphql` block in the `ApiConfig` supports all of the [original mercurius p
 
 An additional `enabled` (boolean) option allows you to disable the graphql server.
 
+### File uploads
+
+GraphQL file uploads ([graphql multipart request spec](https://github.com/jaydenseric/graphql-multipart-request-spec)) are supported out of the box: when the plugin is enabled it registers an upload transport (content-type parser + `graphql-upload-minimal` processing) before mercurius. Configure or disable it with the `uploads` option:
+
+```typescript
+await fastify.register(graphqlPlugin, {
+  ...config.graphql,
+  uploads: { maxFileSize: 10485760 }, // or { enabled: false } to disable
+});
+```
+
+Declare `scalar Upload` in your schema; resolvers receive `Upload` promises. See GUIDE.md (Feature 16) for gotchas, including plugin ordering when combining with REST uploads via `@prefabs.tech/fastify-s3`.
+
 ## Context
 
 The fastify-graphql plugin will generate a graphql context on every request that will include the following attributes:

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -30,7 +30,10 @@
   },
   "dependencies": {
     "@graphql-tools/merge": "9.1.8",
-    "graphql-tag": "2.12.6"
+    "@types/busboy": "1.5.4",
+    "busboy": "1.6.0",
+    "graphql-tag": "2.12.6",
+    "graphql-upload-minimal": "1.6.4"
   },
   "devDependencies": {
     "@prefabs.tech/eslint-config": "0.8.0",

--- a/packages/graphql/src/__test__/uploadTransport.test.ts
+++ b/packages/graphql/src/__test__/uploadTransport.test.ts
@@ -1,0 +1,215 @@
+import type { FastifyInstance } from "fastify";
+
+import Fastify from "fastify";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UPLOAD_TRANSPORT_PLUGIN_NAME } from "../constants";
+import graphqlPlugin from "../plugin";
+import transport from "../uploads/transport";
+
+const schema = `
+  type Query {
+    ping: String
+  }
+`;
+
+const resolvers = {
+  Query: {
+    ping: async () => "pong",
+  },
+};
+
+const BOUNDARY = "----upload-test-boundary";
+
+/** Minimal graphql-multipart-request-spec body (operations, map, one file). */
+const buildGraphqlUploadBody = (): Buffer => {
+  const operations = JSON.stringify({
+    query: "mutation ($file: Upload!) { noop }",
+    variables: { file: null }, // eslint-disable-line unicorn/no-null
+  });
+  const map = JSON.stringify({ 0: ["variables.file"] });
+
+  return Buffer.from(
+    `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="operations"\r\n\r\n` +
+      `${operations}\r\n` +
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="map"\r\n\r\n` +
+      `${map}\r\n` +
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="0"; filename="note.txt"\r\n` +
+      `Content-Type: text/plain\r\n\r\n` +
+      `hello-upload\r\n` +
+      `--${BOUNDARY}--\r\n`,
+    "utf8",
+  );
+};
+
+/** Plain multipart body with one field and one file. */
+const buildPlainMultipartBody = (): Buffer =>
+  Buffer.from(
+    `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="description"\r\n\r\n` +
+      `a plain field\r\n` +
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="doc"; filename="doc.bin"\r\n` +
+      `Content-Type: application/octet-stream\r\n\r\n` +
+      `binary-ish\r\n` +
+      `--${BOUNDARY}--\r\n`,
+    "utf8",
+  );
+
+describe("graphqlUploadTransport — content-type parsing", () => {
+  let fastify: FastifyInstance;
+
+  afterEach(async () => fastify.close());
+
+  it("processes multipart requests to the default /graphql path into an upload body", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(transport);
+
+    let capturedBody: Record<string, unknown> | undefined;
+    fastify.post("/graphql", async (req) => {
+      capturedBody = req.body as Record<string, unknown>;
+      return {};
+    });
+
+    await fastify.ready();
+
+    const response = await fastify.inject({
+      headers: {
+        "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+      },
+      method: "POST",
+      payload: buildGraphqlUploadBody(),
+      url: "/graphql",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedBody?.query).toContain("mutation");
+
+    const variables = capturedBody?.variables as { file: unknown };
+    expect(variables.file).toBeTruthy();
+  });
+
+  it("honors a custom graphql path", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(transport, { path: "/api/gql" });
+
+    let flagged: boolean | undefined;
+    fastify.post("/api/gql", async (req) => {
+      flagged = req.graphqlFileUploadMultipart;
+      return {};
+    });
+
+    await fastify.ready();
+
+    await fastify.inject({
+      headers: {
+        "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+      },
+      method: "POST",
+      payload: buildGraphqlUploadBody(),
+      url: "/api/gql",
+    });
+
+    expect(flagged).toBe(true);
+  });
+
+  it("parses multipart requests outside the graphql path with busboy", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(transport);
+
+    let capturedBody: Record<string, unknown> | undefined;
+    fastify.post("/upload", async (req) => {
+      capturedBody = req.body as Record<string, unknown>;
+      return {};
+    });
+
+    await fastify.ready();
+
+    const response = await fastify.inject({
+      headers: {
+        "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+      },
+      method: "POST",
+      payload: buildPlainMultipartBody(),
+      url: "/upload",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedBody?.description).toBe("a plain field");
+    expect(capturedBody?.doc).toEqual([
+      expect.objectContaining({
+        data: Buffer.from("binary-ish"),
+        filename: "doc.bin",
+        mimetype: "application/octet-stream",
+      }),
+    ]);
+  });
+
+  it("does not return 415 for unknown content types", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(transport);
+
+    fastify.post("/test", async () => ({}));
+    await fastify.ready();
+
+    const response = await fastify.inject({
+      headers: { "content-type": "text/csv" },
+      method: "POST",
+      payload: "a,b,c",
+      url: "/test",
+    });
+
+    expect(response.statusCode).not.toBe(415);
+  });
+});
+
+describe("graphqlPlugin — upload transport registration", () => {
+  let fastify: FastifyInstance;
+
+  afterEach(async () => fastify.close());
+
+  it("registers the upload transport by default when graphql is enabled", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(graphqlPlugin, { enabled: true, resolvers, schema });
+    await fastify.ready();
+
+    expect(fastify.hasPlugin(UPLOAD_TRANSPORT_PLUGIN_NAME)).toBe(true);
+  });
+
+  it("does not register the upload transport when uploads.enabled is false", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(graphqlPlugin, {
+      enabled: true,
+      resolvers,
+      schema,
+      uploads: { enabled: false },
+    });
+    await fastify.ready();
+
+    expect(fastify.hasPlugin(UPLOAD_TRANSPORT_PLUGIN_NAME)).toBe(false);
+  });
+
+  it("does not register the upload transport when graphql is disabled", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(graphqlPlugin, {
+      enabled: false,
+      resolvers,
+      schema,
+    });
+    await fastify.ready();
+
+    expect(fastify.hasPlugin(UPLOAD_TRANSPORT_PLUGIN_NAME)).toBe(false);
+  });
+
+  it("skips its own transport registration when the transport is already registered", async () => {
+    fastify = Fastify({ logger: false });
+    await fastify.register(transport);
+    await fastify.register(graphqlPlugin, { enabled: true, resolvers, schema });
+
+    await expect(fastify.ready()).resolves.toBeDefined();
+    expect(fastify.hasPlugin(UPLOAD_TRANSPORT_PLUGIN_NAME)).toBe(true);
+  });
+});

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -1,0 +1,4 @@
+const DEFAULT_GRAPHQL_PATH = "/graphql";
+const UPLOAD_TRANSPORT_PLUGIN_NAME = "prefabs-graphql-upload-transport";
+
+export { DEFAULT_GRAPHQL_PATH, UPLOAD_TRANSPORT_PLUGIN_NAME };

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -17,14 +17,29 @@ declare module "@prefabs.tech/fastify-config" {
   }
 }
 
+declare module "fastify" {
+  interface FastifyRequest {
+    graphqlFileUploadMultipart?: boolean;
+  }
+}
+
 export { default as baseSchema } from "./baseSchema";
+
+export * from "./constants";
 export { default } from "./plugin";
 export type {
   GraphqlConfig,
   GraphqlEnabledPlugin,
   GraphqlOptions,
+  GraphqlUploadsConfig,
+  MultipartFile,
 } from "./types";
+export { default as graphqlUploadTransport } from "./uploads/transport";
 export { mergeTypeDefs } from "@graphql-tools/merge";
 
 export type { DocumentNode } from "graphql";
 export { gql } from "graphql-tag";
+export type {
+  FileUpload as GraphQLFileUpload,
+  Upload as GraphQLUpload,
+} from "graphql-upload-minimal";

--- a/packages/graphql/src/plugin.ts
+++ b/packages/graphql/src/plugin.ts
@@ -6,6 +6,8 @@ import { mercurius } from "mercurius";
 import type { GraphqlOptions } from "./types";
 
 import buildContext from "./buildContext";
+import { UPLOAD_TRANSPORT_PLUGIN_NAME } from "./constants";
+import graphqlUploadTransport from "./uploads/transport";
 
 const plugin = async (fastify: FastifyInstance, options: GraphqlOptions) => {
   fastify.log.info("Registering fastify-graphql plugin");
@@ -25,6 +27,18 @@ const plugin = async (fastify: FastifyInstance, options: GraphqlOptions) => {
   }
 
   if (options?.enabled) {
+    // Register the upload transport before mercurius so its catch-all
+    // content-type parser is snapshotted into the mercurius context
+    if (
+      options.uploads?.enabled !== false &&
+      !fastify.hasPlugin(UPLOAD_TRANSPORT_PLUGIN_NAME)
+    ) {
+      await fastify.register(graphqlUploadTransport, {
+        path: options.path,
+        ...options.uploads,
+      });
+    }
+
     // Register graphql
     await fastify.register(mercurius, {
       context: buildContext(options.plugins),

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -4,11 +4,13 @@ import type {
   FastifyReply,
   FastifyRequest,
 } from "fastify";
+import type { UploadOptions } from "graphql-upload-minimal";
 import type { MercuriusContext, MercuriusOptions } from "mercurius";
 
 export interface GraphqlConfig extends MercuriusOptions {
   enabled?: boolean;
   plugins?: GraphqlEnabledPlugin[];
+  uploads?: GraphqlUploadsConfig;
 }
 
 export interface GraphqlEnabledPlugin
@@ -21,3 +23,14 @@ export interface GraphqlEnabledPlugin
 }
 
 export type GraphqlOptions = GraphqlConfig;
+
+export interface GraphqlUploadsConfig extends UploadOptions {
+  enabled?: boolean;
+}
+
+export interface MultipartFile {
+  data: Buffer;
+  encoding?: string;
+  filename: string;
+  mimetype: string;
+}

--- a/packages/graphql/src/uploads/processMultipartFormData.ts
+++ b/packages/graphql/src/uploads/processMultipartFormData.ts
@@ -1,0 +1,67 @@
+import type { FastifyRequest } from "fastify";
+
+import Busboy, { FileInfo } from "busboy";
+import { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+
+import type { MultipartFile } from "../types";
+
+const processMultipartFormData = (
+  req: FastifyRequest,
+  _payload: IncomingMessage,
+  done: (err: Error | null, body?: unknown) => void,
+) => {
+  const busboyParser = Busboy({
+    headers: req.headers,
+  });
+
+  const fields: Record<string, string> = {};
+  const files: Record<string, MultipartFile[]> = {};
+
+  busboyParser.on("field", (fieldName, value) => {
+    fields[fieldName] = value;
+  });
+
+  busboyParser.on(
+    "file",
+    (fieldName: string, file: Readable, fileInfo: FileInfo) => {
+      const chunks: Buffer[] = [];
+
+      file.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      file.on("end", () => {
+        const fileBuffer = Buffer.concat(chunks);
+
+        if (!files[fieldName]) {
+          files[fieldName] = [];
+        }
+
+        files[fieldName].push({
+          ...fileInfo,
+          data: fileBuffer,
+          mimetype: fileInfo.mimeType,
+        });
+      });
+    },
+  );
+
+  busboyParser.on("finish", () => {
+    req.body = {
+      ...fields,
+      ...files,
+    };
+
+    // eslint-disable-next-line unicorn/no-null
+    done(null, req.body);
+  });
+
+  busboyParser.on("error", (err) => {
+    req.log.error(err);
+  });
+
+  _payload.pipe(busboyParser);
+};
+
+export { processMultipartFormData };

--- a/packages/graphql/src/uploads/transport.ts
+++ b/packages/graphql/src/uploads/transport.ts
@@ -1,0 +1,55 @@
+import type { FastifyInstance } from "fastify";
+
+import fastifyPlugin from "fastify-plugin";
+import { processRequest } from "graphql-upload-minimal";
+
+import type { GraphqlUploadsConfig } from "../types";
+
+import {
+  DEFAULT_GRAPHQL_PATH,
+  UPLOAD_TRANSPORT_PLUGIN_NAME,
+} from "../constants";
+import { processMultipartFormData } from "./processMultipartFormData";
+
+type UploadTransportOptions = GraphqlUploadsConfig & {
+  path?: string;
+};
+
+const plugin = async (
+  fastify: FastifyInstance,
+  options: UploadTransportOptions,
+) => {
+  const { path, ...uploadOptions } = options;
+  const graphqlPath = path ?? DEFAULT_GRAPHQL_PATH;
+
+  fastify.addContentTypeParser("*", (req, payload, done) => {
+    const contentType = req.headers["content-type"] || "";
+
+    if (contentType.includes("multipart")) {
+      if (req.routeOptions.url?.startsWith(graphqlPath)) {
+        req.graphqlFileUploadMultipart = true;
+      } else {
+        // busboy calls done itself once the body is fully parsed
+        processMultipartFormData(req, payload, done);
+
+        return;
+      }
+    }
+
+    // eslint-disable-next-line unicorn/no-null
+    done(null);
+  });
+
+  fastify.addHook("preValidation", async (request, reply) => {
+    if (!request.graphqlFileUploadMultipart) {
+      return;
+    }
+
+    request.body = await processRequest(request.raw, reply.raw, uploadOptions);
+  });
+};
+
+export default fastifyPlugin(plugin, {
+  fastify: ">= 4.x",
+  name: UPLOAD_TRANSPORT_PLUGIN_NAME,
+});

--- a/packages/s3/FEATURES.md
+++ b/packages/s3/FEATURES.md
@@ -4,13 +4,13 @@
 
 ## Plugin Registration
 
-1. **Main plugin (`default` export)** — Fastify plugin wrapped with `fastify-plugin`. On registration it runs database migrations, conditionally registers `@fastify/multipart` (when `config.rest.enabled` is `true`), and conditionally registers GraphQL upload support (when `config.graphql?.enabled` is `true`).
+1. **Main plugin (`default` export)** — Fastify plugin wrapped with `fastify-plugin`, registered with an `S3Options` object. On registration it runs database migrations, conditionally registers `@fastify/multipart` (when `options.rest?.enabled` is `true`), and conditionally registers GraphQL upload support (when `options.graphql?.enabled` is `true`). Registering without options falls back to composing the options from `fastify.config` (`s3`, `rest`, `graphql` namespaces) with a deprecation warning, and throws if `fastify.config.s3` is also missing. Throws if the `fastify.slonik` decorator is missing (the slonik plugin must be registered first).
 
-2. **Automatic database migration** — On registration the plugin creates (if not exists) the files table using the configured table name (`config.s3.table.name`) or the default name `"files"`.
+2. **Automatic database migration** — On registration the plugin creates (if not exists) the files table using the configured table name (`options.table.name`) or the default name `"files"`.
 
-3. **Conditional REST multipart registration** — When `config.rest.enabled` is `true`, `@fastify/multipart` is registered with `attachFieldsToBody: "keyValues"`, a shared schema id of `"fileSchema"`, a file-size limit from `config.s3.fileSizeLimitInBytes` (defaults to `Infinity`), and an `onFile` hook that converts every part to a `{ data, encoding, filename, mimetype }` object and attaches it as the field value.
+3. **Conditional REST multipart registration** — When `options.rest?.enabled` is `true`, `@fastify/multipart` is registered with `attachFieldsToBody: "keyValues"`, a shared schema id of `"fileSchema"`, a file-size limit from `options.fileSizeLimitInBytes` (defaults to `Infinity`), and an `onFile` hook that converts every part to a `{ data, encoding, filename, mimetype }` object and attaches it as the field value.
 
-4. **Conditional GraphQL upload registration** — When `config.graphql?.enabled` is `true`, the internal `graphqlUpload` plugin is registered, passing `maxFileSize` from `config.s3.fileSizeLimitInBytes` (defaults to `Infinity`).
+4. **Conditional GraphQL upload registration** — When `options.graphql?.enabled` is `true`, the internal `graphqlUpload` plugin is registered, passing `maxFileSize` from `options.fileSizeLimitInBytes` (defaults to `Infinity`).
 
 ## Configuration
 
@@ -27,7 +27,7 @@
 
 7. **`ajvFilePlugin`** — AJV keyword plugin that registers the `isFile` custom keyword. Schemas using `isFile: true` validate that the value is a multipart file object (`{ data, filename, mimetype }`). For array schemas it validates every element. During compile the keyword also rewrites the parent schema (`type: "string"`, `format: "binary"`) so OpenAPI tooling renders a proper file-upload schema.
 
-8. **`multipartParserPlugin`** — Fastify plugin that registers a catch-all `"*"` content-type parser. For multipart requests it routes GraphQL-multipart requests (matching the configured GraphQL path) by setting `req.graphqlFileUploadMultipart = true`, while all other multipart requests are parsed immediately with Busboy into `{ fields..., files... }` and stored on `req.body`. Non-multipart content types fall through unchanged. Augments `FastifyRequest` with the optional `graphqlFileUploadMultipart?: boolean` property.
+8. **`multipartParserPlugin`** — Fastify plugin that registers a catch-all `"*"` content-type parser, registered with a `MultipartParserOptions` object (`{ graphql?: { enabled?, path? } }`). For multipart requests it routes GraphQL-multipart requests (matching `options.graphql.path`, default `"/graphql"`) by setting `req.graphqlFileUploadMultipart = true`, while all other multipart requests are parsed immediately with Busboy into `{ fields..., files... }` and stored on `req.body`. Non-multipart content types fall through unchanged. Registering without options falls back to reading `req.config.graphql` per request with a deprecation warning. Augments `FastifyRequest` with the optional `graphqlFileUploadMultipart?: boolean` property.
 
 ## `S3Client` Utility Class
 
@@ -84,7 +84,7 @@
 
 ## Database Schema (Auto-migrated)
 
-29. **`createFilesTableQuery(config)`** — Returns a `CREATE TABLE IF NOT EXISTS` SQL query for the files table with columns: `id`, `original_file_name`, `bucket`, `description`, `key`, `uploaded_by_id`, `uploaded_at`, `download_count` (default `0`), `last_downloaded_at`, `created_at`, `updated_at`. Table name comes from `config.s3.table.name` or defaults to `"files"`.
+29. **`createFilesTableQuery(config)`** — Returns a `CREATE TABLE IF NOT EXISTS` SQL query for the files table with columns: `id`, `original_file_name`, `bucket`, `description`, `key`, `uploaded_by_id`, `uploaded_at`, `download_count` (default `0`), `last_downloaded_at`, `created_at`, `updated_at`. Accepts an `S3Options` object (table name from `options.table.name`) or, deprecated, a full `ApiConfig` (table name from `config.s3.table.name`); defaults to `"files"`.
 
 ## Error Codes
 
@@ -94,7 +94,7 @@
 
 ## Type Exports
 
-32. **`S3Config`** — Plugin configuration shape (see Feature 5).
+32. **`S3Config`** — Plugin configuration shape (see Feature 5). **`S3Options`** — plugin registration options: `S3Config` plus `graphql?: S3GraphqlConfig` and `rest?: { enabled? }`. **`S3GraphqlConfig`** — `{ enabled?: boolean, path?: string }`. **`MultipartParserOptions`** — options for `multipartParserPlugin` (see Feature 8).
 
 33. **`FilePayload`** — Input type for `FileService.upload`, containing `{ file: { fileContent: Multipart, fileFields: FileCreateInput }, options?: FilePayloadOptions }`.
 

--- a/packages/s3/GUIDE.md
+++ b/packages/s3/GUIDE.md
@@ -79,11 +79,30 @@ await fastify.register(configPlugin, {
 // Register slonik plugin (peer dep) before s3 plugin
 await fastify.register(slonikPlugin);
 
-// Register the S3 plugin
-await fastify.register(s3Plugin);
+// Register the S3 plugin, passing its options directly
+await fastify.register(s3Plugin, {
+  clientConfig: {
+    region: "us-east-1",
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    },
+  },
+  bucket: "my-app-uploads",
+  fileSizeLimitInBytes: 10 * 1024 * 1024, // 10 MB
+  filenameResolutionStrategy: "add-suffix",
+  table: { name: "files" }, // optional, "files" is the default
+  rest: { enabled: true },
+  graphql: { enabled: false },
+});
 
 await fastify.listen({ port: 3000 });
 ```
+
+> **Deprecated**: registering the plugin without options makes it read its
+> configuration from `fastify.config` (`config.s3`, `config.rest`,
+> `config.graphql`) and logs a deprecation warning. This fallback will be
+> removed in a future major release.
 
 ---
 
@@ -147,26 +166,33 @@ Official docs: https://www.npmjs.com/package/uuid
 
 ### 1 — Main plugin registration
 
-Import the default export and register it with Fastify. The plugin uses `fastify-plugin` so decorators are not scoped.
+Import the default export and register it with Fastify, passing an `S3Options` object. The plugin uses `fastify-plugin` so decorators are not scoped.
 
 ```typescript
 import s3Plugin from "@prefabs.tech/fastify-s3";
 
-await fastify.register(s3Plugin);
-// Runs DB migration, registers multipart (if REST enabled),
-// registers GraphQL upload hook (if GraphQL enabled).
+await fastify.register(s3Plugin, {
+  bucket: "my-app-uploads",
+  clientConfig: { region: "us-east-1" },
+  rest: { enabled: true },
+  graphql: { enabled: false },
+});
+// Runs DB migration, registers multipart (if rest.enabled),
+// registers GraphQL upload hook (if graphql.enabled).
 ```
+
+Registering without options falls back to reading `fastify.config.s3`, `fastify.config.rest` and `fastify.config.graphql` (deprecated — logs a warning; the fallback will be removed in a future major release). If neither options nor `fastify.config.s3` are present, registration throws. Registration also throws if `fastify.slonik` is not decorated — the slonik plugin must be registered before the s3 plugin.
 
 ### 2 — Automatic database migration
 
-On every registration the plugin issues `CREATE TABLE IF NOT EXISTS` for the files table. No manual migration command is needed. The table name comes from `config.s3.table.name` (default `"files"`).
+On every registration the plugin issues `CREATE TABLE IF NOT EXISTS` for the files table. No manual migration command is needed. The table name comes from `options.table.name` (default `"files"`).
 
 ### 3 — Conditional REST multipart
 
-When `config.rest.enabled` is `true`, `@fastify/multipart` is registered automatically. File parts are available on `req.body` as `Multipart` objects.
+When `options.rest.enabled` is `true`, `@fastify/multipart` is registered automatically. File parts are available on `req.body` as `Multipart` objects.
 
 ```typescript
-// config
+// plugin options
 rest: {
   enabled: true;
 }
@@ -199,15 +225,17 @@ fastify.post(
 
 ### 4 — Conditional GraphQL upload registration
 
-When `config.graphql?.enabled` is `true`, the plugin registers a `preValidation` hook that calls `processRequest` from `graphql-upload-minimal` for multipart GraphQL requests. You must also register `multipartParserPlugin` to set the `graphqlFileUploadMultipart` flag.
+When `options.graphql?.enabled` is `true`, the plugin registers a `preValidation` hook that calls `processRequest` from `graphql-upload-minimal` for multipart GraphQL requests. You must also register `multipartParserPlugin` to set the `graphqlFileUploadMultipart` flag.
 
 ```typescript
-// config
-graphql: { enabled: true, path: "/graphql" }
-
 // Also register multipartParserPlugin (see Feature 8)
-await fastify.register(multipartParserPlugin);
-await fastify.register(s3Plugin);
+await fastify.register(multipartParserPlugin, {
+  graphql: { enabled: true, path: "/graphql" },
+});
+await fastify.register(s3Plugin, {
+  ...s3Config,
+  graphql: { enabled: true },
+});
 ```
 
 ### 5 — `S3Config` configuration shape
@@ -281,10 +309,14 @@ Register this plugin when your application handles both GraphQL file uploads and
 ```typescript
 import { multipartParserPlugin } from "@prefabs.tech/fastify-s3";
 
-await fastify.register(multipartParserPlugin);
+await fastify.register(multipartParserPlugin, {
+  graphql: { enabled: true, path: "/graphql" }, // path defaults to "/graphql"
+});
 ```
 
 For multipart requests to the GraphQL path, it sets `req.graphqlFileUploadMultipart = true` (the `graphqlUpload` preValidation hook checks this flag). For all other multipart requests it parses the body via Busboy and attaches fields and files to `req.body`.
+
+Registering without options falls back to reading `req.config.graphql` per request (deprecated — logs a warning; the fallback will be removed in a future major release).
 
 ### 9 — `S3Client` class
 
@@ -539,9 +571,11 @@ Exported for consumers who manage their own migration tooling:
 ```typescript
 import { createFilesTableQuery } from "@prefabs.tech/fastify-s3";
 
-const query = createFilesTableQuery(config);
+const query = createFilesTableQuery({ table: { name: "files" } });
 await database.connect(async (conn) => conn.query(query));
 ```
+
+Accepts an `S3Options` object; passing a full `ApiConfig` (reading the table name from `config.s3.table.name`) is still supported but deprecated and will be removed in a future major release.
 
 ### 30 — `ERROR_CODES.FILE_NOT_FOUND`
 

--- a/packages/s3/README.md
+++ b/packages/s3/README.md
@@ -13,7 +13,7 @@ Handling file uploads in a full-stack context requires substantially more effort
 ### Design Decisions: Why not @aws-sdk/client-s3 and @fastify/multipart directly?
 
 - **Too Much Boilerplate**: While those granular tools are fantastic, manually aggregating them to handle incoming parsed streams, S3 buffering, database synchronization, and Swagger schema injection per-route results in massive duplication of boilerplate code across microservices.
-- **Ecosystem Homogenization**: This plugin strictly binds the AWS SDK into our ecosystem's configuration (`fastify-config`) and database architecture (`fastify-slonik`), affording you a unified `FileService` that is ready to execute uploads and metadata queries perfectly right after registration.
+- **Ecosystem Homogenization**: This plugin strictly binds the AWS SDK into our ecosystem's database architecture (`fastify-slonik`), affording you a unified `FileService` that is ready to execute uploads and metadata queries perfectly right after registration.
 
 ## Requirements
 
@@ -90,12 +90,10 @@ When using AWS S3, you are required to enable the following permissions:
 
 ### Register plugin
 
-Register the file fastify-s3 package with your Fastify instance:
+Register the fastify-s3 package with your Fastify instance, passing its options directly. The plugin requires the slonik plugin to be registered first (it stores file metadata in the database); everything else is configured through the plugin's own `S3Options` argument:
 
 ```typescript
-import configPlugin from "@prefabs.tech/fastify-config";
 import errorHandlerPlugin from "@prefabs.tech/fastify-error-handler";
-import graphqlPlugin from "@prefabs.tech/fastify-graphql";
 import s3Plugin from "@prefabs.tech/fastify-s3";
 import slonikPlugin from "@prefabs.tech/fastify-slonik";
 import Fastify from "fastify";
@@ -108,20 +106,21 @@ const start = async () => {
     logger: config.logger,
   });
 
-  // Register config plugin
-  await fastify.register(configPlugin, { config });
-
   await fastify.register(errorHandlerPlugin, {
     stackTrace: process.env.NODE_ENV === "development",
   });
 
-  // Register database plugin
+  // Register database plugin (required by fastify-s3)
   await fastify.register(slonikPlugin, config.slonik);
 
-  await fastify.register(graphqlPlugin, config.graphql);
-
   // Register fastify-s3 plugin (see below for multipartParserPlugin when using GraphQL uploads)
-  await fastify.register(s3Plugin);
+  await fastify.register(s3Plugin, {
+    bucket: "my-app-uploads",
+    clientConfig: {
+      region: "ap-southeast-1",
+    },
+    rest: { enabled: true },
+  });
 
   await fastify.listen({
     host: "0.0.0.0",
@@ -132,28 +131,32 @@ const start = async () => {
 start();
 ```
 
+Registering the plugin without options is deprecated — see [Deprecated: configuration via `fastify.config`](#deprecated-configuration-via-fastifyconfig).
+
 ## Configuration
+
+The plugin is configured with an `S3Options` object passed directly to `register()`.
 
 To initialize Client:
 
 AWS S3 Config
 
 ```typescript
-const config: ApiConfig = {
-  // ... other configurations
+import type { S3Options } from "@prefabs.tech/fastify-s3";
 
-  s3: {
-    bucket: "" | { key: "value" }, // Specify your S3 bucket
-    //... AWS S3 client config
-    clientConfig: {
-      credentials: {
-        accessKeyId: "accessKey", // Replace with your AWS access key
-        secretAccessKey: "secretKey", // Replace with your AWS secret key
-      },
-      region: "ap-southeast-1", // Replace with your AWS region
+const s3Options: S3Options = {
+  bucket: "" | { key: "value" }, // Specify your S3 bucket
+  //... AWS S3 client config
+  clientConfig: {
+    credentials: {
+      accessKeyId: "accessKey", // Replace with your AWS access key
+      secretAccessKey: "secretKey", // Replace with your AWS secret key
     },
+    region: "ap-southeast-1", // Replace with your AWS region
   },
 };
+
+await fastify.register(s3Plugin, s3Options);
 ```
 
 > **Credentials on EC2 (IAM Role)**
@@ -170,20 +173,16 @@ const config: ApiConfig = {
 Minio Service Config
 
 ```typescript
-const config: ApiConfig = {
-  // ... other configurations
-
-  s3: {
-    bucket: "yourMinioBucketName",
-    clientConfig: {
-      credentials: {
-        accessKeyId: "yourMinioAccessKey",
-        secretAccessKey: "yourMinioSecretKey",
-      },
-      endpoint: "http://your-minio-server-url:port", // Replace with your Minio server URL
-      forcePathStyle: true, // Set to true if your Minio server uses path-style URLs
-      region: "", // For Minio, you can leave the region empty or specify it based on your setup
+const s3Options: S3Options = {
+  bucket: "yourMinioBucketName",
+  clientConfig: {
+    credentials: {
+      accessKeyId: "yourMinioAccessKey",
+      secretAccessKey: "yourMinioSecretKey",
     },
+    endpoint: "http://your-minio-server-url:port", // Replace with your Minio server URL
+    forcePathStyle: true, // Set to true if your Minio server uses path-style URLs
+    region: "", // For Minio, you can leave the region empty or specify it based on your setup
   },
 };
 ```
@@ -191,14 +190,10 @@ const config: ApiConfig = {
 To add a custom table name:
 
 ```typescript
-const config: ApiConfig = {
-  // ... other configurations
-
-  s3: {
-    //... AWS S3 client config
-    table: {
-      name: "new-table-name", // You can set a custom table name here (default: "files")
-    },
+const s3Options: S3Options = {
+  //... AWS S3 client config
+  table: {
+    name: "new-table-name", // You can set a custom table name here (default: "files")
   },
 };
 ```
@@ -206,13 +201,9 @@ const config: ApiConfig = {
 To limit the file size while uploading:
 
 ```typescript
-const config: ApiConfig = {
-  // ... other configurations
-
-  s3: {
-    //... AWS S3 client config
-    fileSizeLimitInBytes: 10485760,
-  },
+const s3Options: S3Options = {
+  //... AWS S3 client config
+  fileSizeLimitInBytes: 10485760,
 };
 ```
 
@@ -240,7 +231,6 @@ This package supports integration with [@prefabs.tech/fastify-graphql](../graphq
 Register additional `multipartParserPlugin` plugin with the fastify instance as shown below:
 
 ```typescript
-import configPlugin from "@prefabs.tech/fastify-config";
 import graphqlPlugin from "@prefabs.tech/fastify-graphql";
 import s3Plugin, { multipartParserPlugin } from "@prefabs.tech/fastify-s3";
 import slonikPlugin from "@prefabs.tech/fastify-slonik";
@@ -254,22 +244,27 @@ const start = async () => {
     logger: config.logger,
   });
 
-  // Register config plugin
-  await fastify.register(configPlugin, { config });
-
   // Register database plugin
   await fastify.register(slonikPlugin, config.slonik);
 
   // Register multipart content-type parser plugin (required for graphql file upload or if using both graphql and rest file upload)
-  await fastify.register(multipartParserPlugin);
+  await fastify.register(multipartParserPlugin, {
+    graphql: { enabled: true, path: "/graphql" },
+  });
 
   // Register graphql plugin
   await fastify.register(graphqlPlugin, config.graphql);
 
   // Register fastify-s3 plugin
-  await fastify.register(s3Plugin);
+  await fastify.register(s3Plugin, {
+    bucket: "my-app-uploads",
+    clientConfig: {
+      region: "ap-southeast-1",
+    },
+    graphql: { enabled: true },
+  });
 
-  await await.listen({
+  await fastify.listen({
     host: "0.0.0.0",
     port: config.port,
   });
@@ -285,7 +280,6 @@ start();
 If you want to use @prefabs.tech/fastify-s3 with @fastify/swagger and @fastify/swagger-ui or @prefabs.tech/swagger you must add a new type called `isFile` and use a custom instance of a validator compiler
 
 ```typescript
-import configPlugin from "@prefabs.tech/fastify-config";
 import graphqlPlugin from "@prefabs.tech/fastify-graphql";
 import s3Plugin, {
   ajvFilePlugin,
@@ -306,20 +300,26 @@ const start = async () => {
     },
   });
 
-  // Register config plugin
-  await fastify.register(configPlugin, { config });
-
   // Register database plugin
   await fastify.register(slonikPlugin, config.slonik);
 
   // Register multipart content-type parser plugin (required for graphql file upload or if using both graphql and rest file upload)
-  await fastify.register(multipartParserPlugin);
+  await fastify.register(multipartParserPlugin, {
+    graphql: { enabled: true, path: "/graphql" },
+  });
 
   // Register graphql plugin
   await fastify.register(graphqlPlugin, config.graphql);
 
   // Register fastify-s3 plugin
-  await fastify.register(s3Plugin);
+  await fastify.register(s3Plugin, {
+    bucket: "my-app-uploads",
+    clientConfig: {
+      region: "ap-southeast-1",
+    },
+    graphql: { enabled: true },
+    rest: { enabled: true },
+  });
 
   fastify.post('/upload/file', {
     schema: {
@@ -338,11 +338,38 @@ const start = async () => {
     reply.send('done')
   })
 
-  await await.listen({
+  await fastify.listen({
     port: config.port,
     host: "0.0.0.0",
   });
 }
 
 start();
+```
+
+## Deprecated: configuration via `fastify.config`
+
+Earlier versions of this plugin did not take options: they read their configuration from the fastify instance (`fastify.config`, decorated by [@prefabs.tech/fastify-config](../config/)) — the S3 settings from `config.s3`, and the REST/GraphQL feature flags from the application-wide `config.rest` and `config.graphql` namespaces.
+
+This approach is **deprecated**. The plugin no longer depends on `fastify.config` for its configuration; everything is passed through its own `S3Options` argument as documented above.
+
+For backward compatibility, the old behavior is temporarily still supported:
+
+- **Main plugin** — registering without options composes them from `fastify.config.s3`, `fastify.config.rest` and `fastify.config.graphql`, and logs a deprecation warning. If `fastify.config.s3` is missing too, registration throws.
+- **`multipartParserPlugin`** — registering without options reads `req.config.graphql` per request, and logs a deprecation warning.
+- **`createFilesTableQuery`** — still accepts a full `ApiConfig` (reading `config.s3.table.name`) in addition to the new `S3Options` shape.
+
+This fallback will be removed in a future major release. To migrate, pass the configuration you previously kept under `config.s3` (plus the `rest`/`graphql` flags) directly to `register()`:
+
+```typescript
+// Before (deprecated)
+await fastify.register(configPlugin, { config }); // config.s3, config.rest, config.graphql
+await fastify.register(s3Plugin);
+
+// After
+await fastify.register(s3Plugin, {
+  ...config.s3,
+  graphql: config.graphql,
+  rest: config.rest,
+});
 ```

--- a/packages/s3/src/__test__/multipartParser.test.ts
+++ b/packages/s3/src/__test__/multipartParser.test.ts
@@ -101,6 +101,54 @@ describe("multipartParserPlugin", () => {
     expect(processMultipartFormData).toHaveBeenCalled();
   });
 
+  it("flags graphql multipart requests from options passed to the plugin, without req.config", async () => {
+    fastify = Fastify({ logger: false });
+    const { default: plugin } = await import("../plugins/multipartParser");
+    await fastify.register(plugin, {
+      graphql: { enabled: true, path: "/graphql" },
+    });
+
+    let capturedFlag: boolean | undefined;
+    fastify.post("/graphql", async (req) => {
+      capturedFlag = req.graphqlFileUploadMultipart;
+      return {};
+    });
+
+    await fastify.ready();
+
+    await fastify.inject({
+      headers: { "content-type": "multipart/form-data; boundary=----abc" },
+      method: "POST",
+      payload: "------abc--\r\n",
+      url: "/graphql",
+    });
+
+    expect(capturedFlag).toBe(true);
+  });
+
+  it("defaults the graphql path to /graphql when options.graphql.path is not provided", async () => {
+    fastify = Fastify({ logger: false });
+    const { default: plugin } = await import("../plugins/multipartParser");
+    await fastify.register(plugin, { graphql: { enabled: true } });
+
+    let capturedFlag: boolean | undefined;
+    fastify.post("/graphql", async (req) => {
+      capturedFlag = req.graphqlFileUploadMultipart;
+      return {};
+    });
+
+    await fastify.ready();
+
+    await fastify.inject({
+      headers: { "content-type": "multipart/form-data; boundary=----abc" },
+      method: "POST",
+      payload: "------abc--\r\n",
+      url: "/graphql",
+    });
+
+    expect(capturedFlag).toBe(true);
+  });
+
   it("does not set graphqlFileUploadMultipart when graphql is disabled", async () => {
     fastify = buildFastify({ enabled: false, path: "/graphql" });
     const { default: plugin } = await import("../plugins/multipartParser");

--- a/packages/s3/src/__test__/plugin.test.ts
+++ b/packages/s3/src/__test__/plugin.test.ts
@@ -26,6 +26,13 @@ const buildFastify = (configOverrides: Record<string, unknown> = {}) => {
   return fastify;
 };
 
+/** Fastify instance without a config decoration, for new-pattern tests. */
+const buildBareFastify = () => {
+  const instance = Fastify({ logger: false });
+  instance.decorate("slonik", {});
+  return instance;
+};
+
 /** Minimal multipart/form-data body for inject tests (single file field). */
 const buildMultipartFileBody = (
   boundary: string,
@@ -61,14 +68,115 @@ describe("s3 plugin — initialization", async () => {
     expect(runMigrationsMock).toHaveBeenCalledOnce();
   });
 
-  it("passes slonik and config to runMigrations", async () => {
+  it("passes slonik and the composed options to runMigrations when falling back to fastify.config", async () => {
     fastify = buildFastify();
     await fastify.register(plugin);
     await fastify.ready();
 
     expect(runMigrationsMock).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ s3: expect.any(Object) }),
+      expect.objectContaining({
+        bucket: "test-bucket",
+        rest: { enabled: true },
+      }),
+    );
+  });
+
+  it("logs a deprecation warning when falling back to fastify.config", async () => {
+    fastify = buildFastify();
+    const warnSpy = vi.spyOn(fastify.log, "warn");
+
+    await fastify.register(plugin);
+    await fastify.ready();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("passing s3 options directly"),
+    );
+  });
+
+  it("throws when registered without options and without fastify.config", async () => {
+    fastify = Fastify({ logger: false });
+    fastify.decorate("slonik", {});
+
+    await expect(fastify.register(plugin).ready()).rejects.toThrow(
+      "Missing s3 configuration",
+    );
+  });
+
+  it("throws when the slonik decorator is missing", async () => {
+    fastify = Fastify({ logger: false });
+
+    await expect(
+      fastify
+        .register(plugin, { bucket: "options-bucket", clientConfig: {} })
+        .ready(),
+    ).rejects.toThrow("Missing slonik decorator");
+  });
+});
+
+describe("s3 plugin — options passed directly (new pattern)", async () => {
+  const { default: plugin } = await import("../plugin");
+
+  let fastify: FastifyInstance;
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(async () => fastify.close());
+
+  it("registers @fastify/multipart from options.rest without reading fastify.config", async () => {
+    fastify = buildBareFastify();
+    await fastify.register(plugin, {
+      bucket: "options-bucket",
+      clientConfig: {},
+      rest: { enabled: true },
+    });
+    await fastify.ready();
+
+    expect(fastify.hasContentTypeParser("multipart/form-data")).toBe(true);
+  });
+
+  it("does not register @fastify/multipart when options.rest is omitted", async () => {
+    fastify = buildBareFastify();
+    await fastify.register(plugin, {
+      bucket: "options-bucket",
+      clientConfig: {},
+    });
+    await fastify.ready();
+
+    expect(fastify.hasContentTypeParser("multipart/form-data")).toBe(false);
+  });
+
+  it("registers the graphql upload plugin from options.graphql with maxFileSize from options", async () => {
+    fastify = buildBareFastify();
+    await fastify.register(plugin, {
+      bucket: "options-bucket",
+      clientConfig: {},
+      fileSizeLimitInBytes: 1_000_000,
+      graphql: { enabled: true },
+    });
+    await fastify.ready();
+
+    expect(graphqlUploadMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ maxFileSize: 1_000_000 }),
+      expect.any(Function),
+    );
+  });
+
+  it("passes the options object to runMigrations", async () => {
+    fastify = buildBareFastify();
+    await fastify.register(plugin, {
+      bucket: "options-bucket",
+      clientConfig: {},
+      table: { name: "custom_files" },
+    });
+    await fastify.ready();
+
+    expect(runMigrationsMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        bucket: "options-bucket",
+        table: { name: "custom_files" },
+      }),
     );
   });
 });

--- a/packages/s3/src/__test__/queries.spec.ts
+++ b/packages/s3/src/__test__/queries.spec.ts
@@ -1,0 +1,31 @@
+import type { ApiConfig } from "@prefabs.tech/fastify-config";
+
+import { describe, expect, it } from "vitest";
+
+import type { S3Options } from "../types";
+
+import { createFilesTableQuery } from "../migrations/queries";
+
+describe("createFilesTableQuery", () => {
+  it("uses the table name from S3Options (new pattern)", () => {
+    const query = createFilesTableQuery({
+      table: { name: "uploaded_files" },
+    } as S3Options);
+
+    expect(query.sql).toContain(`"uploaded_files"`);
+  });
+
+  it("uses the table name from a full ApiConfig (deprecated pattern)", () => {
+    const query = createFilesTableQuery({
+      s3: { table: { name: "legacy_files" } },
+    } as unknown as ApiConfig);
+
+    expect(query.sql).toContain(`"legacy_files"`);
+  });
+
+  it("defaults the table name to files", () => {
+    const query = createFilesTableQuery({} as S3Options);
+
+    expect(query.sql).toContain(`"files"`);
+  });
+});

--- a/packages/s3/src/constants.ts
+++ b/packages/s3/src/constants.ts
@@ -1,20 +1,20 @@
-const TABLE_FILES = "files";
-const BUCKET_FROM_OPTIONS = "optionsBucket";
-const BUCKET_FROM_FILE_FIELDS = "fileFieldsBucket";
-
-const OVERWRITE = "overwrite";
 const ADD_SUFFIX = "add-suffix";
+const BUCKET_FROM_FILE_FIELDS = "fileFieldsBucket";
+const BUCKET_FROM_OPTIONS = "optionsBucket";
+const DEFAULT_GRAPHQL_PATH = "/graphql";
 const ERROR = "error";
-
 const ERROR_CODES = {
   FILE_ALREADY_EXISTS_IN_S3: "FILE_ALREADY_EXISTS_IN_S3_ERROR",
   FILE_NOT_FOUND: "FILE_NOT_FOUND_ERROR",
 };
+const OVERWRITE = "overwrite";
+const TABLE_FILES = "files";
 
 export {
   ADD_SUFFIX,
   BUCKET_FROM_FILE_FIELDS,
   BUCKET_FROM_OPTIONS,
+  DEFAULT_GRAPHQL_PATH,
   ERROR,
   ERROR_CODES,
   OVERWRITE,

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -1,3 +1,4 @@
+// Imported for its ApiConfig module augmentation only
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { GraphqlEnabledPlugin } from "@prefabs.tech/fastify-graphql";
 
@@ -16,7 +17,14 @@ export { default as FileService } from "./model/files/service";
 export { default } from "./plugin";
 export { default as ajvFilePlugin } from "./plugins/ajvFile";
 export { default as multipartParserPlugin } from "./plugins/multipartParser";
-export type { FilePayload, Multipart, S3Config } from "./types";
+export type {
+  FilePayload,
+  Multipart,
+  MultipartParserOptions,
+  S3Config,
+  S3GraphqlConfig,
+  S3Options,
+} from "./types";
 export type { File, FileCreateInput, FileUpdateInput } from "./types/file";
 
 export { default as S3Client } from "./utils/s3Client";

--- a/packages/s3/src/migrations/queries.ts
+++ b/packages/s3/src/migrations/queries.ts
@@ -3,12 +3,18 @@ import type { ZodTypeAny } from "zod";
 
 import { QuerySqlToken, sql } from "slonik";
 
+import type { S3Options } from "../types";
+
 import { TABLE_FILES } from "../constants";
 
+// Accepts S3Options (new pattern) or a full ApiConfig (deprecated) during the
+// migration window; the ApiConfig overload will be removed in a future major.
 const createFilesTableQuery = (
-  config: ApiConfig,
+  config: ApiConfig | Partial<S3Options>,
 ): QuerySqlToken<ZodTypeAny> => {
-  const tableName = config.s3?.table?.name || TABLE_FILES;
+  const tableName =
+    ("s3" in config ? config.s3?.table?.name : config.table?.name) ||
+    TABLE_FILES;
 
   return sql.unsafe`
     CREATE TABLE IF NOT EXISTS ${sql.identifier([tableName])} (

--- a/packages/s3/src/migrations/runMigrations.ts
+++ b/packages/s3/src/migrations/runMigrations.ts
@@ -1,11 +1,15 @@
-import type { ApiConfig } from "@prefabs.tech/fastify-config";
 import type { Database } from "@prefabs.tech/fastify-slonik";
+
+import type { S3Options } from "../types";
 
 import { createFilesTableQuery } from "./queries";
 
-const runMigrations = async (database: Database, config: ApiConfig) => {
+const runMigrations = async (
+  database: Database,
+  options: Partial<S3Options>,
+) => {
   await database.connect(async (connection) => {
-    await connection.query(createFilesTableQuery(config));
+    await connection.query(createFilesTableQuery(options));
   });
 };
 

--- a/packages/s3/src/plugin.ts
+++ b/packages/s3/src/plugin.ts
@@ -3,21 +3,51 @@ import type { FastifyInstance } from "fastify";
 import fastifyMultiPart from "@fastify/multipart";
 import FastifyPlugin from "fastify-plugin";
 
+import type { S3Options } from "./types";
+
 import runMigrations from "./migrations/runMigrations";
 import graphqlGQLUpload from "./plugins/graphqlUpload";
 
-const plugin = async (fastify: FastifyInstance) => {
+// Partial so the deprecated no-options registration still compiles; the
+// parameter becomes a required S3Options once the fastify.config fallback is
+// removed.
+const plugin = async (
+  fastify: FastifyInstance,
+  options: Partial<S3Options>,
+) => {
   fastify.log.info("Registering fastify-s3 plugin");
 
-  const { config, slonik } = fastify;
+  if (!fastify.slonik) {
+    throw new Error(
+      "Missing slonik decorator. Did you forget to register the slonik plugin before the s3 plugin?",
+    );
+  }
 
-  await runMigrations(slonik, config);
+  if (Object.keys(options).length === 0) {
+    fastify.log.warn(
+      "The s3 plugin now recommends passing s3 options directly to the plugin.",
+    );
 
-  if (config.rest.enabled) {
+    if (!fastify.config?.s3) {
+      throw new Error(
+        "Missing s3 configuration. Did you forget to pass it to the s3 plugin?",
+      );
+    }
+
+    options = {
+      ...fastify.config.s3,
+      graphql: fastify.config.graphql,
+      rest: fastify.config.rest,
+    };
+  }
+
+  await runMigrations(fastify.slonik, options);
+
+  if (options.rest?.enabled) {
     await fastify.register(fastifyMultiPart, {
       attachFieldsToBody: "keyValues",
       limits: {
-        fileSize: config.s3.fileSizeLimitInBytes || Number.POSITIVE_INFINITY,
+        fileSize: options.fileSizeLimitInBytes || Number.POSITIVE_INFINITY,
       },
       async onFile(part) {
         // @ts-expect-error: data value and data is missing in MultipartFile type
@@ -32,9 +62,9 @@ const plugin = async (fastify: FastifyInstance) => {
     });
   }
 
-  if (config.graphql?.enabled) {
+  if (options.graphql?.enabled) {
     await fastify.register(graphqlGQLUpload, {
-      maxFileSize: config.s3.fileSizeLimitInBytes || Number.POSITIVE_INFINITY,
+      maxFileSize: options.fileSizeLimitInBytes || Number.POSITIVE_INFINITY,
     });
   }
 };

--- a/packages/s3/src/plugins/multipartParser.ts
+++ b/packages/s3/src/plugins/multipartParser.ts
@@ -2,6 +2,9 @@ import type { FastifyInstance } from "fastify";
 
 import fastifyPlugin from "fastify-plugin";
 
+import type { MultipartParserOptions } from "../types";
+
+import { DEFAULT_GRAPHQL_PATH } from "../constants";
 import { processMultipartFormData } from "../utils";
 
 declare module "fastify" {
@@ -10,14 +13,24 @@ declare module "fastify" {
   }
 }
 
-const plugin = async (fastify: FastifyInstance) => {
+const plugin = async (
+  fastify: FastifyInstance,
+  options: MultipartParserOptions,
+) => {
+  if (Object.keys(options).length === 0) {
+    fastify.log.warn(
+      "The multipart parser plugin now recommends passing graphql options directly to the plugin.",
+    );
+  }
+
   fastify.addContentTypeParser("*", (req, _payload, done) => {
     const contentType = req.headers["content-type"] || "";
+    const graphql = options.graphql ?? req.config?.graphql;
 
     if (contentType.includes("multipart")) {
       if (
-        req.config.graphql?.enabled &&
-        req.routeOptions.url?.startsWith(req.config.graphql.path as string)
+        graphql?.enabled &&
+        req.routeOptions.url?.startsWith(graphql.path ?? DEFAULT_GRAPHQL_PATH)
       ) {
         req.graphqlFileUploadMultipart = true;
       } else {

--- a/packages/s3/src/types/index.ts
+++ b/packages/s3/src/types/index.ts
@@ -44,6 +44,10 @@ interface Multipart {
   mimetype: string;
 }
 
+interface MultipartParserOptions {
+  graphql?: S3GraphqlConfig;
+}
+
 interface PresignedUrlOptions extends BaseOption {
   signedUrlExpiresInSecond?: number;
 }
@@ -57,14 +61,29 @@ interface S3Config {
   };
 }
 
+interface S3GraphqlConfig {
+  enabled?: boolean;
+  path?: string;
+}
+
+type S3Options = S3Config & {
+  graphql?: S3GraphqlConfig;
+  rest?: {
+    enabled?: boolean;
+  };
+};
+
 export type {
   BucketChoice,
   FilenameResolutionStrategy,
   FilePayload,
   FilePayloadOptions,
   Multipart,
+  MultipartParserOptions,
   PresignedUrlOptions,
   S3Config,
+  S3GraphqlConfig,
+  S3Options,
 };
 
 export type * from "./file";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,9 +200,18 @@ importers:
       '@graphql-tools/merge':
         specifier: 9.1.8
         version: 9.1.8(graphql@16.13.2)
+      '@types/busboy':
+        specifier: 1.5.4
+        version: 1.5.4
+      busboy:
+        specifier: 1.6.0
+        version: 1.6.0
       graphql-tag:
         specifier: 2.12.6
         version: 2.12.6(graphql@16.13.2)
+      graphql-upload-minimal:
+        specifier: 1.6.4
+        version: 1.6.4(graphql@16.13.2)
     devDependencies:
       '@prefabs.tech/eslint-config':
         specifier: 0.8.0


### PR DESCRIPTION
…llback

The plugin now takes an S3Options argument (S3Config + rest/graphql flags).
Registering without options falls back to composing options from
fastify.config with a deprecation warning; the fallback will be removed in
a future major. Also guards the required fastify.slonik decorator with an
actionable error.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>