### PR TITLE
feat(error-handler): include requestId in every error response

### DIFF
--- a/packages/error-handler/FEATURES.md
+++ b/packages/error-handler/FEATURES.md
@@ -53,6 +53,7 @@
       error?: string;             // HTTP status text (HttpErrors and mapped domain errors)
       message: string;            // error message (masked for unmapped non-HttpErrors when stackTrace: false; mapped errors use the thrown message)
       name: string;               // error class name (masked for unmapped non-HttpErrors when stackTrace: false; mapped errors use the thrown name)
+      requestId: string;          // fastify request id (request.id), so a failure response can be correlated with its log entries
       stack?: StackTracey.Entry[] // parsed stack frames (only when stackTrace: true)
       statusCode: number;         // HTTP status code
     }

--- a/packages/error-handler/README.md
+++ b/packages/error-handler/README.md
@@ -25,6 +25,7 @@ All options from [@fastify/sensible](https://www.npmjs.com/package/@fastify/sens
 - **`CustomError` base class** — extend it to create domain errors with a custom `code` field; subclasses are handled safely
 - **`stackTrace` option** — controls whether parsed stack frames are included in error responses
 - **`ErrorResponse` JSON schema** — registered as `$id: "ErrorResponse"` for use in route response schemas via `$ref: "ErrorResponse#"`
+- **Request-id correlation** — every error response includes `requestId` (fastify's `request.id`), so a client-reported failure can be matched to its request-scoped log entries
 - **Severity-aware logging** — 4xx errors log at `info`, 5xx at `error`; non-Error thrown values are normalized and logged safely
 - **`domainErrorStatusMap`** — optional app-provided `Map<string, number>` from `error.name` to an HTTP status integer **`400`–`599`** (invalid entries fail at registration); the plugin stores a validated copy. Mapped errors return that status with message/name (and `CustomError` `code`) in the body—only **unmapped** non-`HttpError` errors use generic masking when `stackTrace` is false
 

--- a/packages/error-handler/src/__test__/requestId.test.ts
+++ b/packages/error-handler/src/__test__/requestId.test.ts
@@ -1,0 +1,76 @@
+/* istanbul ignore file */
+import Fastify from "fastify";
+import { afterEach, describe, expect, it } from "vitest";
+
+import errorHandlerPlugin, { CustomError } from "../index";
+import { buildFastify, FastifyInstance } from "./helpers";
+
+class DomainError extends CustomError {
+  constructor(message: string) {
+    super(message, "DOMAIN_ERROR");
+    this.name = "DOMAIN_ERROR";
+  }
+}
+
+describe("errorHandlerPlugin — requestId in error responses", () => {
+  let fastify: FastifyInstance;
+
+  afterEach(async () => await fastify.close());
+
+  it("HttpError responses carry the request id", async () => {
+    fastify = await buildFastify();
+    fastify.get("/not-found", async () => {
+      throw fastify.httpErrors.notFound("User not found");
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/not-found" });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().requestId).toBe("req-1");
+  });
+
+  it("domain-mapped error responses carry the request id", async () => {
+    fastify = await buildFastify({
+      domainErrorStatusMap: new Map([["DOMAIN_ERROR", 404]]),
+    });
+    fastify.get("/domain", async () => {
+      throw new DomainError("not found");
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/domain" });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().requestId).toBe("req-1");
+  });
+
+  it("unhandled 500 responses carry the request id", async () => {
+    fastify = await buildFastify({ stackTrace: false });
+    fastify.get("/boom", async () => {
+      throw new Error("secret");
+    });
+
+    const res = await fastify.inject({ method: "GET", url: "/boom" });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().requestId).toBe("req-1");
+  });
+
+  it("echoes the id supplied via the configured request-id header", async () => {
+    // The load balancer (or client) sets the request id; the error response
+    // must quote the same id so the failure can be found in the logs.
+    fastify = Fastify({ logger: false, requestIdHeader: "x-request-id" });
+    await fastify.register(errorHandlerPlugin, {});
+    fastify.get("/boom", async () => {
+      throw new Error("secret");
+    });
+
+    const res = await fastify.inject({
+      headers: { "x-request-id": "lb-trace-42" },
+      method: "GET",
+      url: "/boom",
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().requestId).toBe("lb-trace-42");
+  });
+});

--- a/packages/error-handler/src/errorHandler.ts
+++ b/packages/error-handler/src/errorHandler.ts
@@ -15,6 +15,7 @@ function canSendDomainMappedError(
   domainErrorStatusMap: ReadonlyMap<string, number> | undefined,
   reply: FastifyReply,
   logger: FastifyRequest["log"],
+  requestId: string,
   isStackTraceEnabled: boolean,
   stack: StackTracey,
 ): boolean {
@@ -37,6 +38,7 @@ function canSendDomainMappedError(
     error: getHttpStatusText(mappedStatusCode),
     message: error.message,
     name: error.name,
+    requestId,
     statusCode: mappedStatusCode,
   };
 
@@ -82,6 +84,7 @@ export const errorHandler = (
       error: error.error || getHttpStatusText(statusCode),
       message: error.message,
       name: error.name,
+      requestId: request.id,
       statusCode,
     };
 
@@ -100,6 +103,7 @@ export const errorHandler = (
       options.domainErrorStatusMap,
       reply,
       logger,
+      request.id,
       isStackTraceEnabled,
       stack,
     )
@@ -119,6 +123,7 @@ export const errorHandler = (
     code: isStackTraceEnabled ? code : "INTERNAL_SERVER_ERROR",
     message: isStackTraceEnabled ? error.message : message,
     name: isStackTraceEnabled ? error.name : "Error",
+    requestId: request.id,
     statusCode: 500,
   };
 

--- a/packages/error-handler/src/types.ts
+++ b/packages/error-handler/src/types.ts
@@ -18,6 +18,7 @@ type ErrorResponse = {
   error?: string;
   message: string;
   name: string;
+  requestId: string;
   stack?: StackTracey.Entry[];
   statusCode: number;
 };

--- a/packages/error-handler/src/utils/errorSchema.ts
+++ b/packages/error-handler/src/utils/errorSchema.ts
@@ -6,6 +6,7 @@ export const errorSchema = {
     error: { type: "string" },
     message: { type: "string" },
     name: { type: "string" },
+    requestId: { type: "string" },
     stack: {
       items: {
         additionalProperties: true,


### PR DESCRIPTION
Every error response now carries `requestId` (fastify's `request.id`) alongside the existing fields. When the app configures `requestIdHeader` (e.g. a load balancer's `x-request-id`), that same id is echoed back, so a client-reported failure can be correlated directly with its request-scoped log entries instead of searching by message and timestamp.

Additive change: new field on the `ErrorResponse` type, the registered `ErrorResponse` JSON schema, and all three handler branches (HttpError, domain-mapped, unhandled 500). No behavioural change to status codes or logging. New `requestId.test.ts` covers all three lanes plus header-supplied ids; README/FEATURES updated. 55/55 tests, typecheck and lint clean.